### PR TITLE
Multiple/Parallel PHP Version Support

### DIFF
--- a/cli/Valet/Nginx.php
+++ b/cli/Valet/Nginx.php
@@ -136,6 +136,9 @@ class Nginx
      */
     public function installNginxConfig($valetSite, $phpVersion = null)
     {
+        // TODO: Need to check if site has SSL
+        // if so maybe need to update the secured file insted
+
         $versionInteger = preg_replace('~[^\d]~', '', $phpVersion);
 
         $this->files->putAsUser(

--- a/cli/Valet/Nginx.php
+++ b/cli/Valet/Nginx.php
@@ -80,30 +80,13 @@ class Nginx
             str_replace(
                 ['VALET_HOME_PATH', 'VALET_SERVER_PATH', 'VALET_STATIC_PREFIX'],
                 [VALET_HOME_PATH, VALET_SERVER_PATH, VALET_STATIC_PREFIX],
-                $this->replaceLoopback($this->files->get(__DIR__.'/../stubs/valet.conf'))
+                $this->site->replaceLoopback($this->files->get(__DIR__.'/../stubs/valet.conf'))
             )
         );
 
         $this->files->putAsUser(
             BREW_PREFIX.'/etc/nginx/fastcgi_params',
             $this->files->get(__DIR__.'/../stubs/fastcgi_params')
-        );
-    }
-
-    public function replaceLoopback($siteConf)
-    {
-        $loopback = $this->configuration->read()['loopback'];
-
-        if ($loopback === VALET_LOOPBACK) {
-            return $siteConf;
-        }
-
-        $str = '#listen VALET_LOOPBACK:80; # valet loopback';
-
-        return str_replace(
-            $str,
-            substr(str_replace('VALET_LOOPBACK', $loopback, $str), 1),
-            $siteConf
         );
     }
 
@@ -125,32 +108,6 @@ class Nginx
         $this->files->putAsUser($nginxDirectory.'/.keep', "\n");
 
         $this->rewriteSecureNginxFiles();
-    }
-
-
-    /**
-     * Build the Nginx server for the given valet site.
-     *
-     * @param  string  $valetSite
-     * @param  string  $fpmSockName
-     * @param $phpVersion
-     *
-     * @return void
-     */
-    public function installSiteConfig($valetSite, $fpmSockName, $phpVersion)
-    {
-        if ($this->files->exists($this->site->nginxPath($valetSite))) {
-            $siteConf = $this->files->get($this->site->nginxPath($valetSite));
-            $siteConf = $this->site->replaceSockFile($siteConf, $fpmSockName, $phpVersion);
-        }else{
-            $siteConf = str_replace(
-                ['VALET_HOME_PATH', 'VALET_SERVER_PATH', 'VALET_STATIC_PREFIX', 'VALET_SITE', 'VALET_PHP_FPM_SOCKET', 'VALET_ISOLATED_PHP_VERSION'],
-                [VALET_HOME_PATH, VALET_SERVER_PATH, VALET_STATIC_PREFIX, $valetSite, $fpmSockName, $phpVersion],
-                $this->replaceLoopback($this->files->get(__DIR__.'/../stubs/site.valet.conf'))
-            );
-        }
-
-        $this->files->putAsUser($this->site->nginxPath($valetSite), $siteConf);
     }
 
     /**

--- a/cli/Valet/Nginx.php
+++ b/cli/Valet/Nginx.php
@@ -141,10 +141,7 @@ class Nginx
     {
         if ($this->files->exists($this->site->nginxPath($valetSite))) {
             $siteConf = $this->files->get($this->site->nginxPath($valetSite));
-            $siteConf = preg_replace("/valet[0-9]*.sock/", $fpmSockName, $siteConf);
-            if (! starts_with($siteConf, '# Valet isolated PHP version')) {
-                $siteConf = '# Valet isolated PHP version : '.$phpVersion.PHP_EOL.$siteConf;
-            }
+            $siteConf = $this->site->replaceSockFile($siteConf, $fpmSockName, $phpVersion);
         }else{
             $siteConf = str_replace(
                 ['VALET_HOME_PATH', 'VALET_SERVER_PATH', 'VALET_STATIC_PREFIX', 'VALET_SITE', 'VALET_PHP_FPM_SOCKET', 'VALET_ISOLATED_PHP_VERSION'],

--- a/cli/Valet/Nginx.php
+++ b/cli/Valet/Nginx.php
@@ -127,6 +127,27 @@ class Nginx
         $this->rewriteSecureNginxFiles();
     }
 
+
+    /**
+     * Build the Nginx server for the given URL.
+     *
+     * @param  string  $valetSite
+     * @param  string  $phpVersion
+     */
+    public function installNginxConfig($valetSite, $phpVersion = null)
+    {
+        $versionInteger = preg_replace('~[^\d]~', '', $phpVersion);
+
+        $this->files->putAsUser(
+            $this->site->nginxPath($valetSite),
+            str_replace(
+                ['VALET_HOME_PATH', 'VALET_SERVER_PATH', 'VALET_STATIC_PREFIX', 'VALET_SITE', 'VALET_PHP_FPM_SOCKET'],
+                [VALET_HOME_PATH, VALET_SERVER_PATH, VALET_STATIC_PREFIX, $valetSite, "valet{$versionInteger}.sock"],
+                $this->replaceLoopback($this->files->get(__DIR__.'/../stubs/site.valet.conf'))
+            )
+        );
+    }
+
     /**
      * Check nginx.conf for errors.
      */

--- a/cli/Valet/Nginx.php
+++ b/cli/Valet/Nginx.php
@@ -142,6 +142,9 @@ class Nginx
         if ($this->files->exists($this->site->nginxPath($valetSite))) {
             $siteConf = $this->files->get($this->site->nginxPath($valetSite));
             $siteConf = preg_replace("/valet[0-9]*.sock/", $fpmSockName, $siteConf);
+            if (! starts_with($siteConf, '# Valet isolated PHP version')) {
+                $siteConf = '# Valet isolated PHP version : '.$phpVersion.PHP_EOL.$siteConf;
+            }
         }else{
             $siteConf = str_replace(
                 ['VALET_HOME_PATH', 'VALET_SERVER_PATH', 'VALET_STATIC_PREFIX', 'VALET_SITE', 'VALET_PHP_FPM_SOCKET', 'VALET_ISOLATED_PHP_VERSION'],

--- a/cli/Valet/PhpFpm.php
+++ b/cli/Valet/PhpFpm.php
@@ -198,7 +198,7 @@ class PhpFpm
         } catch (DomainException $e) { /* ignore thrown exception when no linked php is found */
         }
 
-        if (!$this->brew->installed($version)) {
+        if (! $this->brew->installed($version)) {
             // Install the relevant formula if not already installed
             $this->brew->ensureInstalled($version, [], $this->taps);
         }
@@ -259,7 +259,7 @@ class PhpFpm
     {
         $version = $this->normalizePhpVersion($version);
 
-        if (!$this->brew->supportedPhpVersions()->contains($version)) {
+        if (! $this->brew->supportedPhpVersions()->contains($version)) {
             throw new DomainException(
                 sprintf(
                     'Valet doesn\'t support PHP version: %s (try something like \'php@7.3\' instead)',

--- a/cli/Valet/PhpFpm.php
+++ b/cli/Valet/PhpFpm.php
@@ -323,8 +323,8 @@ class PhpFpm
     }
 
     /**
-     * check all custom nginx config files
-     * look for the php version and maybe delete that custom config
+     * Check all custom nginx config files
+     * Look for the php version and maybe adjust that custom config
      *
      * @param $newPhpVersion
      * @param $oldPhpVersion
@@ -339,7 +339,7 @@ class PhpFpm
                 $content = $this->files->get(VALET_HOME_PATH.'/Nginx/'.$file);
 
                 if (strpos($content, $this->fpmSocketName($newPhpVersion)) !== false) {
-                    info(sprintf('Updating site %s to keep using version: %s', $file, $oldPhpVersion));
+                    info(sprintf('Updating site %s to keep using version: %s', $file, $newPhpVersion));
                     $this->files->put(VALET_HOME_PATH.'/Nginx/'.$file, str_replace($this->fpmSocketName($newPhpVersion), 'valet.sock', $content));
                 } elseif (strpos($content, 'valet.sock') !== false) {
                     info(sprintf('Updating site %s to keep using version: %s', $file, $oldPhpVersion));

--- a/cli/Valet/PhpFpm.php
+++ b/cli/Valet/PhpFpm.php
@@ -34,10 +34,9 @@ class PhpFpm
      * Install and configure PhpFpm.
      *
      * @param  null  $phpVersion
-     * @param  null  $valetSite
      * @return void
      */
-    public function install($phpVersion = null, $valetSite = null)
+    public function install($phpVersion = null)
     {
         if (! $this->brew->hasInstalledPhp()) {
             $this->brew->ensureInstalled('php', [], $this->taps);
@@ -206,7 +205,7 @@ class PhpFpm
         // we need to unlink and link only for global php version change
         if ($site) {
             $this->cli->quietly('sudo rm '.VALET_HOME_PATH."/". $this->fpmSockName($version));
-            $this->install($version, $site);
+            $this->install($version);
         } else {
             // Unlink the current php if there is one
             if ($this->brew->hasLinkedPhp()) {

--- a/cli/Valet/Site.php
+++ b/cli/Valet/Site.php
@@ -191,6 +191,17 @@ class Site
     }
 
     /**
+     * Determine if the provided site is parked
+     *
+     * @param $valetSite
+     * @return bool
+     */
+    function isValidSite($valetSite)
+    {
+        return $this->parked()->whereIn('url', ['http://' . $valetSite , 'https://' . $valetSite])->count() > 0;
+    }
+
+    /**
      * Identify whether a site is for a proxy by reading the host name from its config file.
      *
      * @param  string  $site  Site name without TLD

--- a/cli/Valet/Site.php
+++ b/cli/Valet/Site.php
@@ -198,7 +198,10 @@ class Site
      */
     function isValidSite($valetSite)
     {
-        return $this->parked()->whereIn('url', ['http://' . $valetSite , 'https://' . $valetSite])->count() > 0;
+        // remove .tld to make the search a bit easier
+        $siteName = str_replace('.'.$this->config->read()['tld'], '', $valetSite);
+
+        return $this->parked()->merge($this->links())->where('site', $siteName)->count() > 0;
     }
 
     /**

--- a/cli/Valet/Site.php
+++ b/cli/Valet/Site.php
@@ -665,6 +665,27 @@ class Site
         );
     }
 
+
+    /**
+     * Build the Nginx server for the given URL.
+     *
+     * @param  string  $url
+     * @param  string  $version
+     */
+    public function buildNginxServer($url, $version = null)
+    {
+        $versionInteger = preg_replace('~[^\d]~', '', $version);
+
+        $this->files->putAsUser(
+            $this->nginxPath($url), $this->buildSecureNginxServer($url, str_replace(
+                    ['VALET_HOME_PATH', 'VALET_SERVER_PATH', 'VALET_STATIC_PREFIX', 'SITE_URL', 'VALET_PHP_FPM_SOCKET'],
+                    [VALET_HOME_PATH, VALET_SERVER_PATH, VALET_STATIC_PREFIX, $url, "valet{$versionInteger}.sock"],
+                    $this->files->get(__DIR__.'/../stubs/site.valet.conf')
+                )
+            )
+        );
+    }
+
     /**
      * Unsecure the given URL so that it will use HTTP again.
      *

--- a/cli/Valet/Site.php
+++ b/cli/Valet/Site.php
@@ -677,11 +677,11 @@ class Site
         $versionInteger = preg_replace('~[^\d]~', '', $version);
 
         $this->files->putAsUser(
-            $this->nginxPath($url), $this->buildSecureNginxServer($url, str_replace(
-                    ['VALET_HOME_PATH', 'VALET_SERVER_PATH', 'VALET_STATIC_PREFIX', 'VALET_SITE', 'VALET_PHP_FPM_SOCKET'],
-                    [VALET_HOME_PATH, VALET_SERVER_PATH, VALET_STATIC_PREFIX, $url, "valet{$versionInteger}.sock"],
-                    $this->files->get(__DIR__.'/../stubs/site.valet.conf')
-                )
+            $this->nginxPath($url),
+            str_replace(
+                ['VALET_HOME_PATH', 'VALET_SERVER_PATH', 'VALET_STATIC_PREFIX', 'VALET_SITE', 'VALET_PHP_FPM_SOCKET'],
+                [VALET_HOME_PATH, VALET_SERVER_PATH, VALET_STATIC_PREFIX, $url, "valet{$versionInteger}.sock"],
+                $this->files->get(__DIR__.'/../stubs/site.valet.conf')
             )
         );
     }

--- a/cli/Valet/Site.php
+++ b/cli/Valet/Site.php
@@ -1003,7 +1003,7 @@ class Site
     }
 
     /**
-     * Replace .sock file form a ngin site conf
+     * Replace .sock file form a nginx site conf
      *
      * @param $siteConf
      * @param $sockFile

--- a/cli/Valet/Site.php
+++ b/cli/Valet/Site.php
@@ -665,44 +665,6 @@ class Site
         );
     }
 
-
-    /**
-     * Build the Nginx server for the given URL.
-     *
-     * @param  string  $valetSite
-     * @param  string  $phpVersion
-     */
-    public function installNginxConfig($valetSite, $phpVersion = null)
-    {
-        $versionInteger = preg_replace('~[^\d]~', '', $phpVersion);
-
-        $this->files->putAsUser(
-            $this->nginxPath($valetSite),
-            str_replace(
-                ['VALET_HOME_PATH', 'VALET_SERVER_PATH', 'VALET_STATIC_PREFIX', 'VALET_SITE', 'VALET_PHP_FPM_SOCKET'],
-                [VALET_HOME_PATH, VALET_SERVER_PATH, VALET_STATIC_PREFIX, $valetSite, "valet{$versionInteger}.sock"],
-                $this->replaceLoopback($this->files->get(__DIR__.'/../stubs/site.valet.conf'))
-            )
-        );
-    }
-
-    public function replaceLoopback($siteConf)
-    {
-        $loopback = $this->config->read()['loopback'];
-
-        if ($loopback === VALET_LOOPBACK) {
-            return $siteConf;
-        }
-
-        $str = '#listen VALET_LOOPBACK:80; # valet loopback';
-
-        return str_replace(
-            $str,
-            substr(str_replace('VALET_LOOPBACK', $loopback, $str), 1),
-            $siteConf
-        );
-    }
-
     /**
      * Unsecure the given URL so that it will use HTTP again.
      *

--- a/cli/Valet/Site.php
+++ b/cli/Valet/Site.php
@@ -678,7 +678,7 @@ class Site
 
         $this->files->putAsUser(
             $this->nginxPath($url), $this->buildSecureNginxServer($url, str_replace(
-                    ['VALET_HOME_PATH', 'VALET_SERVER_PATH', 'VALET_STATIC_PREFIX', 'SITE_URL', 'VALET_PHP_FPM_SOCKET'],
+                    ['VALET_HOME_PATH', 'VALET_SERVER_PATH', 'VALET_STATIC_PREFIX', 'VALET_SITE', 'VALET_PHP_FPM_SOCKET'],
                     [VALET_HOME_PATH, VALET_SERVER_PATH, VALET_STATIC_PREFIX, $url, "valet{$versionInteger}.sock"],
                     $this->files->get(__DIR__.'/../stubs/site.valet.conf')
                 )

--- a/cli/Valet/Site.php
+++ b/cli/Valet/Site.php
@@ -485,7 +485,7 @@ class Site
      */
     public function secure($url, $siteConf = null, $certificateExpireInDays = 396, $caExpireInYears = 20)
     {
-        $phpVersion = $this->extractPhpVersion($url); // let's try to preserve the isolated php version here
+        $phpVersion = $this->extractPhpVersion($url); // let's try to preserve the isolated php version here. Example output: 74
 
         $this->unsecure($url);
 
@@ -505,7 +505,7 @@ class Site
         // if user had any isolated php version, let's swap the .sock file,
         // so it still uses the old php version
         if ($phpVersion) {
-            $this->replaceSockFile($siteConf, "valet{$phpVersion}.sock", $phpVersion);
+            $siteConf = $this->replaceSockFile($siteConf, "valet{$phpVersion}.sock", $phpVersion);
         }
 
         $this->files->putAsUser($this->nginxPath($url), $siteConf);

--- a/cli/stubs/site.valet.conf
+++ b/cli/stubs/site.valet.conf
@@ -1,0 +1,39 @@
+server {
+    listen 127.0.0.1:80;
+    server_name SITE_URL www.SITE_URL *.SITE_URL;
+    #listen VALET_LOOPBACK:80; # valet loopback
+    root /;
+    charset utf-8;
+    client_max_body_size 128M;
+
+    location /VALET_STATIC_PREFIX/ {
+        internal;
+        alias /;
+        try_files $uri $uri/;
+    }
+
+    location / {
+        rewrite ^ "VALET_SERVER_PATH" last;
+    }
+
+    location = /favicon.ico { access_log off; log_not_found off; }
+    location = /robots.txt  { access_log off; log_not_found off; }
+
+    access_log off;
+    error_log "VALET_HOME_PATH/Log/nginx-error.log";
+
+    error_page 404 "VALET_SERVER_PATH";
+
+    location ~ [^/]\.php(/|$) {
+        fastcgi_split_path_info ^(.+\.php)(/.+)$;
+        fastcgi_pass "unix:VALET_HOME_PATH/VALET_PHP_FPM_SOCKET";
+        fastcgi_index "VALET_SERVER_PATH";
+        include fastcgi_params;
+        fastcgi_param SCRIPT_FILENAME "VALET_SERVER_PATH";
+        fastcgi_param PATH_INFO $fastcgi_path_info;
+    }
+
+    location ~ /\.ht {
+        deny all;
+    }
+}

--- a/cli/stubs/site.valet.conf
+++ b/cli/stubs/site.valet.conf
@@ -1,6 +1,6 @@
 server {
     listen 127.0.0.1:80;
-    server_name SITE_URL www.SITE_URL *.SITE_URL;
+    server_name VALET_SITE www.VALET_SITE *.VALET_SITE;
     #listen VALET_LOOPBACK:80; # valet loopback
     root /;
     charset utf-8;

--- a/cli/stubs/site.valet.conf
+++ b/cli/stubs/site.valet.conf
@@ -1,3 +1,4 @@
+# Valet isolated PHP version : VALET_ISOLATED_PHP_VERSION
 server {
     listen 127.0.0.1:80;
     server_name VALET_SITE www.VALET_SITE *.VALET_SITE;

--- a/cli/valet.php
+++ b/cli/valet.php
@@ -518,7 +518,7 @@ You might also want to investigate your global Composer configs. Helpful command
 
             $newVersion = PhpFpm::useVersion($phpVersion, $force, $site);
 
-            Nginx::installNginxConfig($site, $phpVersion);
+            Nginx::installSiteConfig($site, PhpFpm::fpmSockName($phpVersion), $phpVersion);
             Nginx::restart();
 
             info(sprintf('Site %s is now using %s.', $site, $newVersion));

--- a/cli/valet.php
+++ b/cli/valet.php
@@ -493,7 +493,7 @@ You might also want to investigate your global Composer configs. Helpful command
     /**
      * Allow the user to change the version of php valet uses.
      */
-    $app->command('use [phpVersion] [--force]', function ($phpVersion, $force) {
+    $app->command('use [phpVersion] [--force] [--site=]', function ($phpVersion, $force, $site) {
         if (! $phpVersion) {
             $path = getcwd().'/.valetphprc';
             $linkedVersion = Brew::linkedPhp();
@@ -511,7 +511,15 @@ You might also want to investigate your global Composer configs. Helpful command
 
         PhpFpm::validateRequestedVersion($phpVersion);
 
-        $newVersion = PhpFpm::useVersion($phpVersion, $force);
+        // @TODO: validate site
+        // Site::validate($site);
+        // dump($site);
+
+        $newVersion = PhpFpm::useVersion($phpVersion, $force, $site);
+
+        if($site){
+            Site::buildNginxServer($site, $phpVersion);
+        }
 
         Nginx::restart();
         info(sprintf('Valet is now using %s.', $newVersion).PHP_EOL);

--- a/cli/valet.php
+++ b/cli/valet.php
@@ -518,7 +518,7 @@ You might also want to investigate your global Composer configs. Helpful command
         $newVersion = PhpFpm::useVersion($phpVersion, $force, $site);
 
         if($site){
-            Site::installNginxConfig($site, $phpVersion);
+            Nginx::installNginxConfig($site, $phpVersion);
         }
 
         Nginx::restart();

--- a/cli/valet.php
+++ b/cli/valet.php
@@ -518,7 +518,7 @@ You might also want to investigate your global Composer configs. Helpful command
 
             $newVersion = PhpFpm::useVersion($phpVersion, $force, $site);
 
-            Nginx::installSiteConfig($site, PhpFpm::fpmSockName($phpVersion), $phpVersion);
+            Site::installSiteConfig($site, PhpFpm::fpmSockName($phpVersion), $phpVersion);
             Nginx::restart();
 
             info(sprintf('Site %s is now using %s.', $site, $newVersion));

--- a/cli/valet.php
+++ b/cli/valet.php
@@ -531,6 +531,7 @@ You might also want to investigate your global Composer configs. Helpful command
 
     })->descriptions('Change the version of PHP used by valet', [
         'phpVersion' => 'The PHP version you want to use, e.g php@7.3',
+        '--site' => 'Isolate PHP version of a specific valet site. (Example: --site=site.test)',
     ]);
 
     /**

--- a/cli/valet.php
+++ b/cli/valet.php
@@ -525,7 +525,7 @@ You might also want to investigate your global Composer configs. Helpful command
             Site::installSiteConfig($site, PhpFpm::fpmSockName($phpVersion), $phpVersion);
             Nginx::restart();
 
-            info(sprintf('Site %s is now using %s.', $site, $newVersion));
+            info(sprintf('The [%s] site is now using %s.', $site, $newVersion));
         } else {
             $newVersion = PhpFpm::useVersion($phpVersion, $force);
             Nginx::restart();
@@ -535,7 +535,7 @@ You might also want to investigate your global Composer configs. Helpful command
 
     })->descriptions('Change the version of PHP used by valet', [
         'phpVersion' => 'The PHP version you want to use, e.g php@7.3',
-        '--site' => 'Isolate PHP version of a specific valet site. (Example: --site=site.test)',
+        '--site' => 'Isolate PHP version of a specific valet site. e.g: --site=site.test',
     ]);
 
     /**

--- a/cli/valet.php
+++ b/cli/valet.php
@@ -511,8 +511,12 @@ You might also want to investigate your global Composer configs. Helpful command
 
         PhpFpm::validateRequestedVersion($phpVersion);
 
-        if ($site){
-            if(! Site::isValidSite($site)) {
+        if ($site) {
+            if ($site == '.') { // allow user to use dot as current dir's site `--site=.`
+                $site = Site::host(getcwd()).'.'.Configuration::read()['tld'];
+            }
+
+            if (! Site::isValidSite($site)) {
                 return warning(sprintf('Site %s could not be found in valet site list.', $site));
             }
 

--- a/cli/valet.php
+++ b/cli/valet.php
@@ -511,20 +511,24 @@ You might also want to investigate your global Composer configs. Helpful command
 
         PhpFpm::validateRequestedVersion($phpVersion);
 
-        // @TODO: validate site
-        // Site::validate($site);
-        // dump($site);
-
-        $newVersion = PhpFpm::useVersion($phpVersion, $force, $site);
-
         if($site){
+            if(! Site::isValidSite($site)){
+                return warning(sprintf('Site %s could not be found in valet site list.', $site));
+            }
+
+            $newVersion = PhpFpm::useVersion($phpVersion, $force, $site);
+
             Nginx::installNginxConfig($site, $phpVersion);
+            Nginx::restart();
+
+            info(sprintf('Site %s is now using %s.', $site, $newVersion));
+        }else{
+            $newVersion = PhpFpm::useVersion($phpVersion, $force);
+            Nginx::restart();
+            info(sprintf('Valet is now using %s.', $newVersion).PHP_EOL);
+            info('Note that you might need to run <comment>composer global update</comment> if your PHP version change affects the dependencies of global packages required by Composer.');
         }
 
-        Nginx::restart();
-
-        info(sprintf('Valet is now using %s.', $newVersion).PHP_EOL);
-        info('Note that you might need to run <comment>composer global update</comment> if your PHP version change affects the dependencies of global packages required by Composer.');
     })->descriptions('Change the version of PHP used by valet', [
         'phpVersion' => 'The PHP version you want to use, e.g php@7.3',
     ]);

--- a/cli/valet.php
+++ b/cli/valet.php
@@ -518,10 +518,11 @@ You might also want to investigate your global Composer configs. Helpful command
         $newVersion = PhpFpm::useVersion($phpVersion, $force, $site);
 
         if($site){
-            Site::buildNginxServer($site, $phpVersion);
+            Site::installNginxConfig($site, $phpVersion);
         }
 
         Nginx::restart();
+
         info(sprintf('Valet is now using %s.', $newVersion).PHP_EOL);
         info('Note that you might need to run <comment>composer global update</comment> if your PHP version change affects the dependencies of global packages required by Composer.');
     })->descriptions('Change the version of PHP used by valet', [

--- a/cli/valet.php
+++ b/cli/valet.php
@@ -511,8 +511,8 @@ You might also want to investigate your global Composer configs. Helpful command
 
         PhpFpm::validateRequestedVersion($phpVersion);
 
-        if($site){
-            if(! Site::isValidSite($site)){
+        if ($site){
+            if(! Site::isValidSite($site)) {
                 return warning(sprintf('Site %s could not be found in valet site list.', $site));
             }
 
@@ -522,7 +522,7 @@ You might also want to investigate your global Composer configs. Helpful command
             Nginx::restart();
 
             info(sprintf('Site %s is now using %s.', $site, $newVersion));
-        }else{
+        } else {
             $newVersion = PhpFpm::useVersion($phpVersion, $force);
             Nginx::restart();
             info(sprintf('Valet is now using %s.', $newVersion).PHP_EOL);


### PR DESCRIPTION
# Multiple/Parallel PHP Version Support 

This pull request introduces an optional `--site` flag on the `valet use` command, that allows users to run multiple versions of PHP in parallel on different sites. 

Btw, I build this feature to solve my very own problem. I need to constantly switch between PHP versions, as I need to switch between old and new projects. This is being very handy for me. 


### To isolate a site's PHP version, run: 

```bash
valet use php@8.0 --site=site.test

or 

valet use php@8.1 --site=site2.test
```

or `cd` into the site's directory then run:
```bash
valet use php@8.1 --site .
```

### Behind the scene:
- Updates the FPM config file `/etc/php/8.0/php-fpm.d/valet-fpm.conf` and updates the listen parameter to something like: `valet80.sock`
- Publishes an Nginx config file on the `~/.config/valet/Nginx` location for that site.
- Updates that specific Nginx config file and replaces the `fastcgi_pass` param with `valet80.sock`

### Few other notes: 
- System default linked PHP will keep running on `valet.sock` as expected. 
- Global PHP switching commands like `valet use php@7.4` would still work as expected. Alongside, it will perform some operations on the isolated site's Nginx config to make sure those isolated sites still work as expected. 
- Running `valet install` or `valet restart` would do a scan on isolated sites to determine what versions of PHP are being used.  So it can restart each version of PHP correctly. 
- SSL-enabled sites could be isolated with the usual command. (or isolated site can obtain SSL, as well)
- Running `valet unsecure` on an isolated site will still keep the isolation and will remove the SSL.

### Feature todos: 
- Need to have another command to list all the isolated sites and their PHP versions. (would be handy to check that)
- Ideally, we would need to have a way to remove isolation for a site (maybe a command or a `--rm` flag?)


This modification doesn't seem to break any existing test cases or any existing flows. But I'll be here to add more tests on the new feature if the maintainer is positive about adding this feature into the official repo. 