### PR TITLE
Valet Run RND

### DIFF
--- a/cli/Valet/Brew.php
+++ b/cli/Valet/Brew.php
@@ -2,6 +2,7 @@
 
 namespace Valet;
 
+use PhpFpm;
 use DomainException;
 
 class Brew

--- a/cli/Valet/Brew.php
+++ b/cli/Valet/Brew.php
@@ -516,7 +516,7 @@ class Brew
      * @param  string  $versionB
      * @return bool
      */
-    public function arePhpVersionsEqual($versionA, $version)
+    public function arePhpVersionsEqual($versionA, $versionB)
     {
         $versionANormalized = preg_replace('/[^\d]/', '', $versionA);
         $versionBNormalized = preg_replace('/[^\d]/', '', $versionB);

--- a/cli/Valet/Brew.php
+++ b/cli/Valet/Brew.php
@@ -280,7 +280,7 @@ class Brew
 
         return $this->supportedPhpVersions()->first(
             function ($version) use ($resolvedPhpVersion) {
-                return $this->isPhpVersionsEqual($resolvedPhpVersion, $version);
+                return $this->arePhpVersionsEqual($resolvedPhpVersion, $version);
             }, function () use ($resolvedPhpVersion) {
                 throw new DomainException("Unable to determine linked PHP when parsing '$resolvedPhpVersion'");
             });
@@ -289,7 +289,7 @@ class Brew
     /**
      * Extract PHP executable path from PHP Version.
      *
-     * @param  string  $phpVersion
+     * @param  string  $phpVersion  For example, "php@8.1"
      * @return string
      */
     public function getPhpExecutablePath($phpVersion = null)
@@ -314,7 +314,8 @@ class Brew
             $resolvedPath = $this->files->readLink(BREW_PREFIX.'/opt/php');
             $matches = $this->parsePhpPath($resolvedPath);
             $resolvedPhpVersion = $matches[3] ?: $matches[2];
-            if ($this->isPhpVersionsEqual($resolvedPhpVersion, $phpVersion)) {
+
+            if ($this->arePhpVersionsEqual($resolvedPhpVersion, $phpVersion)) {
                 return BREW_PREFIX.'/opt/php/bin/php';
             }
         }
@@ -511,15 +512,15 @@ class Brew
     /**
      * Check if two PHP versions are equal.
      *
-     * @param  string  $resolvedPhpVersion
-     * @param  string  $version
+     * @param  string  $versionA
+     * @param  string  $versionB
      * @return bool
      */
-    public function isPhpVersionsEqual($resolvedPhpVersion, $version)
+    public function arePhpVersionsEqual($versionA, $version)
     {
-        $resolvedVersionNormalized = preg_replace('/[^\d]/', '', $resolvedPhpVersion);
-        $versionNormalized = preg_replace('/[^\d]/', '', $version);
+        $versionANormalized = preg_replace('/[^\d]/', '', $versionA);
+        $versionBNormalized = preg_replace('/[^\d]/', '', $versionB);
 
-        return $resolvedVersionNormalized === $versionNormalized;
+        return $versionANormalized === $versionBNormalized;
     }
 }

--- a/cli/Valet/Brew.php
+++ b/cli/Valet/Brew.php
@@ -304,18 +304,18 @@ class Brew
         }
 
         // Check the `/opt/homebrew/opt/php71/bin/php` location for older installations
-        $phpVersion = str_replace(['@', '.'], '' , $phpVersion); // php@8.1 to php81
+        $phpVersion = str_replace(['@', '.'], '', $phpVersion); // php@8.1 to php81
         if ($this->files->exists(BREW_PREFIX."/opt/{$phpVersion}/bin/php")) {
             return BREW_PREFIX."/opt/{$phpVersion}/bin/php";
         }
 
         // Check if the default PHP is the version we are looking for
-        if ($this->files->isLink(BREW_PREFIX."/opt/php")) {
-            $resolvedPath = $this->files->readLink(BREW_PREFIX."/opt/php");
+        if ($this->files->isLink(BREW_PREFIX.'/opt/php')) {
+            $resolvedPath = $this->files->readLink(BREW_PREFIX.'/opt/php');
             $matches = $this->parsePhpPath($resolvedPath);
             $resolvedPhpVersion = $matches[3] ?: $matches[2];
             if ($this->isPhpVersionsEqual($resolvedPhpVersion, $phpVersion)) {
-                return BREW_PREFIX."/opt/php/bin/php";
+                return BREW_PREFIX.'/opt/php/bin/php';
             }
         }
 
@@ -489,10 +489,9 @@ class Brew
     }
 
     /**
-     * Parse homebrew PHP Path
+     * Parse homebrew PHP Path.
      *
      * @param  string  $resolvedPath
-     *
      * @return mixed
      */
     public function parsePhpPath($resolvedPath)
@@ -510,11 +509,10 @@ class Brew
     }
 
     /**
-     * Check if two PHP versions are equal
+     * Check if two PHP versions are equal.
      *
-     * @param string $resolvedPhpVersion
-     * @param string $version
-     *
+     * @param  string  $resolvedPhpVersion
+     * @param  string  $version
      * @return bool
      */
     public function isPhpVersionsEqual($resolvedPhpVersion, $version)

--- a/cli/Valet/Brew.php
+++ b/cli/Valet/Brew.php
@@ -2,8 +2,8 @@
 
 namespace Valet;
 
-use PhpFpm;
 use DomainException;
+use PhpFpm;
 
 class Brew
 {

--- a/cli/Valet/Brew.php
+++ b/cli/Valet/Brew.php
@@ -326,7 +326,8 @@ class Brew
             }
         }
 
-        // Create a symlink to the Valet PHP version, so next time valet won't have to look for the executable path
+        // If the symlinked Valet PHP path doesn't exist, then we need to look for the correct executable path
+        // Create a symlink to the Valet PHP version, so next time Valet won't have to look for the executable path
         if ($phpExecutablePath = $this->getPhpExecutablePath($phpVersion)) {
             $this->files->symlinkAsUser($phpExecutablePath, $symlinkedValetPhpPath);
         }
@@ -346,7 +347,6 @@ class Brew
     {
         $phpExecutablePath = null;
 
-        // If the symlinked Valet PHP path doesn't exist, then we need to look for the correct executable path
         $cellar = $this->cli->runAsUser("brew --cellar $phpVersion"); // Example output: `/opt/homebrew/Cellar/php@8.0`
         $details = json_decode($this->cli->runAsUser("brew info --json $phpVersion"), true);
         $phpDirectory = data_get($details, '0.linked_keg');

--- a/cli/Valet/Brew.php
+++ b/cli/Valet/Brew.php
@@ -492,7 +492,7 @@ class Brew
      * Parse homebrew PHP Path.
      *
      * @param  string  $resolvedPath
-     * @return mixed
+     * @return array
      */
     public function parsePhpPath($resolvedPath)
     {

--- a/cli/Valet/Brew.php
+++ b/cli/Valet/Brew.php
@@ -309,6 +309,7 @@ class Brew
     public function getPhpBinaryPath($phpVersion)
     {
         $versionInteger = preg_replace('~[^\d]~', '', $phpVersion);
+        $binPath = null;
 
         if (file_exists(BREW_PREFIX . "/bin/valetphp{$versionInteger}")) {
             return BREW_PREFIX . "/bin/valetphp{$versionInteger}";
@@ -320,28 +321,19 @@ class Brew
         $path = !empty($details[0]->linked_keg) ? $details[0]->linked_keg : $details[0]->installed[0]->version;
 
         if (file_exists(trim($cellar).'/'.$path.'/bin/php')) {
-           return trim($cellar).'/'.$path.'/bin/php';
+            $binPath = trim($cellar).'/'.$path.'/bin/php';
         }
 
-        if (file_exists(BREW_PREFIX . "/opt/$phpVersion/bin/php")) {
-            return BREW_PREFIX . "/opt/$phpVersion/bin/php";
+        // if (!$binPath && file_exists(BREW_PREFIX . "/opt/$phpVersion/bin/php")) {
+        //     return BREW_PREFIX . "/opt/$phpVersion/bin/php";
+        // }
+
+        if($binPath){
+            $this->files->symlinkAsUser($binPath, BREW_PREFIX . "/bin/valetphp{$versionInteger}");
+            return $binPath;
         }
 
         return "php";
-    }
-
-    /**
-     * Create a PHP binary symlink for a PHP version
-     *
-     * @param string $phpVersion
-     *
-     * @return void
-     */
-    public function symlinkPhpBinary($phpVersion)
-    {
-        $versionInteger = preg_replace('~[^\d]~', '', $phpVersion);
-
-        $this->files->symlinkAsUser($this->getPhpBinaryPath($phpVersion), BREW_PREFIX . "/bin/valetphp{$versionInteger}");
     }
 
     /**

--- a/cli/Valet/Brew.php
+++ b/cli/Valet/Brew.php
@@ -311,8 +311,11 @@ class Brew
         $versionInteger = preg_replace('~[^\d]~', '', $phpVersion);
         $binPath = null;
 
-        if (file_exists(BREW_PREFIX . "/bin/valetphp{$versionInteger}")) {
-            return BREW_PREFIX . "/bin/valetphp{$versionInteger}";
+        if ($this->files->isLink(BREW_PREFIX . "/bin/valetphp{$versionInteger}")) {
+            $binPath = $this->files->readLink(BREW_PREFIX . "/bin/valetphp{$versionInteger}");
+            if($this->files->exists($binPath)){
+                return $binPath;
+            }
         }
 
         $cellar = $this->cli->runAsUser("brew --cellar $phpVersion");
@@ -320,11 +323,11 @@ class Brew
 
         $path = !empty($details[0]->linked_keg) ? $details[0]->linked_keg : $details[0]->installed[0]->version;
 
-        if (file_exists(trim($cellar).'/'.$path.'/bin/php')) {
+        if ($this->files->exists(trim($cellar).'/'.$path.'/bin/php')) {
             $binPath = trim($cellar).'/'.$path.'/bin/php';
         }
 
-        // if (!$binPath && file_exists(BREW_PREFIX . "/opt/$phpVersion/bin/php")) {
+        // if (!$binPath && $this->>files->exists(BREW_PREFIX . "/opt/$phpVersion/bin/php")) {
         //     return BREW_PREFIX . "/opt/$phpVersion/bin/php";
         // }
 

--- a/cli/Valet/Brew.php
+++ b/cli/Valet/Brew.php
@@ -300,7 +300,7 @@ class Brew
 
 
     /**
-     * Get PHP binary path for a given PHP Version
+     * Get PHP executable path for a given PHP Version
      *
      * @param string|null $phpVersion
      * @param boolean $skipCache
@@ -318,34 +318,35 @@ class Brew
 
         // If the symlinked Valet PHP path exists, then we can use that
         if (!$skipCache && $this->files->isLink($symlinkedValetPhpPath)) {
-            $phpBinaryPath = $this->files->readLink($symlinkedValetPhpPath);
+            $phpExecutablePath = $this->files->readLink($symlinkedValetPhpPath);
 
-            // Still make sure that the version of the binary exists
-            if ($this->files->exists($phpBinaryPath)) {
-                return $phpBinaryPath;
+            // Still make sure that the version of the executable exists
+            if ($this->files->exists($phpExecutablePath)) {
+                return $phpExecutablePath;
             }
         }
 
-        // Create a symlink to the Valet PHP version, so next time valet won't have to look for the binary path
-        if ($phpBinaryPath = $this->getPhpBinaryPath($phpVersion)) {
-            $this->files->symlinkAsUser($phpBinaryPath, $symlinkedValetPhpPath);
+        // Create a symlink to the Valet PHP version, so next time valet won't have to look for the executable path
+        if ($phpExecutablePath = $this->getPhpExecutablePath($phpVersion)) {
+            $this->files->symlinkAsUser($phpExecutablePath, $symlinkedValetPhpPath);
         }
 
-        return $phpBinaryPath ?: BREW_PREFIX.'/bin/php';
+        return $phpExecutablePath ?: BREW_PREFIX.'/bin/php';
     }
 
 
     /**
-     * Get PHP binary path from PHP Version
+     * Extract PHP executable path from PHP Version
      *
      * @param  string  $phpVersion
+     *
      * @return string
      */
-    public function getPhpBinaryPath($phpVersion)
+    public function getPhpExecutablePath($phpVersion)
     {
-        $phpBinaryPath = null;
+        $phpExecutablePath = null;
 
-        // If the symlinked Valet PHP path doesn't exist, then we need to look for the correct binary path
+        // If the symlinked Valet PHP path doesn't exist, then we need to look for the correct executable path
         $cellar = $this->cli->runAsUser("brew --cellar $phpVersion"); // Example output: `/opt/homebrew/Cellar/php@8.0`
         $details = json_decode($this->cli->runAsUser("brew info --json $phpVersion"), true);
         $phpDirectory = data_get($details, '0.linked_keg');
@@ -359,15 +360,15 @@ class Brew
         }
 
         if (isset($phpDirectory) && $this->files->exists(trim($cellar).'/'.$phpDirectory.'/bin/php')) {
-            $phpBinaryPath = trim($cellar).'/'.$phpDirectory.'/bin/php';
+            $phpExecutablePath = trim($cellar).'/'.$phpDirectory.'/bin/php';
         }
 
         // When PHP Version is installed directly though shivammathur/homebrew-php, it usually stores the binaries in this directory
-        if (is_null($phpBinaryPath) && $this->files->exists(BREW_PREFIX."/opt/{$phpVersion}/bin/php")) {
-            $phpBinaryPath = BREW_PREFIX."/opt/{$phpVersion}/bin/php";
+        if (is_null($phpExecutablePath) && $this->files->exists(BREW_PREFIX."/opt/{$phpVersion}/bin/php")) {
+            $phpExecutablePath = BREW_PREFIX."/opt/{$phpVersion}/bin/php";
         }
 
-        return $phpBinaryPath;
+        return $phpExecutablePath;
     }
 
     /**

--- a/cli/Valet/Brew.php
+++ b/cli/Valet/Brew.php
@@ -304,12 +304,14 @@ class Brew
      *
      * @param string $phpVersion
      *
-     * @return string|bool
+     * @return string
      */
     public function getPhpBinaryPath($phpVersion)
     {
-        if (file_exists(BREW_PREFIX . "/opt/$phpVersion/bin/php")) {
-            return BREW_PREFIX . "/opt/$phpVersion/bin/php";
+        $versionInteger = preg_replace('~[^\d]~', '', $phpVersion);
+
+        if (file_exists(BREW_PREFIX . "/bin/valetphp{$versionInteger}")) {
+            return BREW_PREFIX . "/bin/valetphp{$versionInteger}";
         }
 
         $cellar = $this->cli->runAsUser("brew --cellar $phpVersion");
@@ -321,7 +323,25 @@ class Brew
            return trim($cellar).'/'.$path.'/bin/php';
         }
 
+        if (file_exists(BREW_PREFIX . "/opt/$phpVersion/bin/php")) {
+            return BREW_PREFIX . "/opt/$phpVersion/bin/php";
+        }
+
         return "php";
+    }
+
+    /**
+     * Create a PHP binary symlink for a PHP version
+     *
+     * @param string $phpVersion
+     *
+     * @return void
+     */
+    public function symlinkPhpBinary($phpVersion)
+    {
+        $versionInteger = preg_replace('~[^\d]~', '', $phpVersion);
+
+        $this->files->symlinkAsUser($this->getPhpBinaryPath($phpVersion), BREW_PREFIX . "/bin/valetphp{$versionInteger}");
     }
 
     /**

--- a/cli/Valet/Brew.php
+++ b/cli/Valet/Brew.php
@@ -298,6 +298,8 @@ class Brew
             return BREW_PREFIX.'/bin/php';
         }
 
+        $phpVersion = PhpFpm::normalizePhpVersion($phpVersion);
+
         // Check the default `/opt/homebrew/opt/php@8.1/bin/php` location first
         if ($this->files->exists(BREW_PREFIX."/opt/{$phpVersion}/bin/php")) {
             return BREW_PREFIX."/opt/{$phpVersion}/bin/php";

--- a/cli/Valet/Brew.php
+++ b/cli/Valet/Brew.php
@@ -298,26 +298,24 @@ class Brew
             });
     }
 
-
     /**
-     * Get PHP executable path for a given PHP Version
+     * Get PHP executable path for a given PHP Version.
      *
-     * @param string|null $phpVersion
-     * @param boolean $skipCache
-     *
+     * @param  string|null  $phpVersion
+     * @param  bool  $skipCache
      * @return string
      */
     public function whichPhp($phpVersion = null, $skipCache = false)
     {
-        if(! $phpVersion){
+        if (! $phpVersion) {
             return BREW_PREFIX.'/bin/php';
         }
 
         $versionInteger = preg_replace('~[^\d]~', '', $phpVersion);
-        $symlinkedValetPhpPath = BREW_PREFIX. "/bin/valetphp{$versionInteger}";
+        $symlinkedValetPhpPath = BREW_PREFIX."/bin/valetphp{$versionInteger}";
 
         // If the symlinked Valet PHP path exists, then we can use that
-        if (!$skipCache && $this->files->isLink($symlinkedValetPhpPath)) {
+        if (! $skipCache && $this->files->isLink($symlinkedValetPhpPath)) {
             $phpExecutablePath = $this->files->readLink($symlinkedValetPhpPath);
 
             // Still make sure that the version of the executable exists
@@ -335,12 +333,10 @@ class Brew
         return $phpExecutablePath ?: BREW_PREFIX.'/bin/php';
     }
 
-
     /**
-     * Extract PHP executable path from PHP Version
+     * Extract PHP executable path from PHP Version.
      *
      * @param  string  $phpVersion
-     *
      * @return string
      */
     public function getPhpExecutablePath($phpVersion)

--- a/cli/Valet/Brew.php
+++ b/cli/Valet/Brew.php
@@ -298,6 +298,32 @@ class Brew
             });
     }
 
+
+    /**
+     * Get PHP binary path for a given version
+     *
+     * @param string $phpVersion
+     *
+     * @return string|bool
+     */
+    public function getPhpBinaryPath($phpVersion)
+    {
+        if (file_exists(BREW_PREFIX . "/opt/$phpVersion/bin/php")) {
+            return BREW_PREFIX . "/opt/$phpVersion/bin/php";
+        }
+
+        $cellar = $this->cli->runAsUser("brew --cellar $phpVersion");
+        $details = json_decode($this->cli->runAsUser("brew info --json $phpVersion"));
+
+        $path = !empty($details[0]->linked_keg) ? $details[0]->linked_keg : $details[0]->installed[0]->version;
+
+        if (file_exists(trim($cellar).'/'.$path.'/bin/php')) {
+           return trim($cellar).'/'.$path.'/bin/php';
+        }
+
+        return "php";
+    }
+
     /**
      * Restart the linked PHP-FPM Homebrew service.
      *

--- a/cli/Valet/PhpFpm.php
+++ b/cli/Valet/PhpFpm.php
@@ -221,7 +221,6 @@ class PhpFpm
         $this->createConfigurationFiles($version);
 
         $this->site->isolate($site, $version);
-        $this->brew->symlinkPhpBinary($version);
 
         $this->stopIfUnused($oldCustomPhpVersion);
         $this->restart($version);

--- a/cli/Valet/PhpFpm.php
+++ b/cli/Valet/PhpFpm.php
@@ -322,7 +322,7 @@ class PhpFpm
     /**
      * If passed php7.4, or php74, 7.4, or 74 formats, normalize to php@7.4 format.
      */
-    public function normalizePhpVersion($version)
+    public static function normalizePhpVersion($version)
     {
         return preg_replace('/(?:php@?)?([0-9+])(?:.)?([0-9+])/i', 'php@$1.$2', $version);
     }

--- a/cli/Valet/PhpFpm.php
+++ b/cli/Valet/PhpFpm.php
@@ -322,7 +322,7 @@ class PhpFpm
     /**
      * If passed php7.4, or php74, 7.4, or 74 formats, normalize to php@7.4 format.
      */
-    public static function normalizePhpVersion($version)
+    public function normalizePhpVersion($version)
     {
         return preg_replace('/(?:php@?)?([0-9+])(?:.)?([0-9+])/i', 'php@$1.$2', $version);
     }

--- a/cli/Valet/PhpFpm.php
+++ b/cli/Valet/PhpFpm.php
@@ -221,6 +221,7 @@ class PhpFpm
         $this->createConfigurationFiles($version);
 
         $this->site->isolate($site, $version);
+        $this->brew->symlinkPhpBinary($version);
 
         $this->stopIfUnused($oldCustomPhpVersion);
         $this->restart($version);

--- a/cli/Valet/Site.php
+++ b/cli/Valet/Site.php
@@ -3,6 +3,7 @@
 namespace Valet;
 
 use DomainException;
+use PhpFpm;
 
 class Site
 {
@@ -1107,5 +1108,22 @@ class Site
         $siteConf = preg_replace('/# '.ISOLATED_PHP_VERSION.'.*\n/', '', $siteConf); // Remove ISOLATED_PHP_VERSION line from config
 
         return '# '.ISOLATED_PHP_VERSION.'='.$phpVersion.PHP_EOL.$siteConf;
+    }
+
+    /**
+     * Get PHP version from .valetphprc for a site.
+     *
+     * @param  string  $site
+     * @return string|null
+     */
+    public function phpRcVersion($site)
+    {
+        if ($site = $this->parked()->merge($this->links())->where('site', $site)->first()) {
+            $path = data_get($site, 'path').'/.valetphprc';
+
+            if ($this->files->exists($path)) {
+                return PhpFpm::normalizePhpVersion(trim($this->files->get($path)));
+            }
+        }
     }
 }

--- a/cli/valet.php
+++ b/cli/valet.php
@@ -555,10 +555,17 @@ You might also want to investigate your global Composer configs. Helpful command
     /**
      * List isolated sites.
      */
-    $app->command('isolated', function () {
-        $sites = PhpFpm::isolatedDirectories();
+    $app->command('isolated [--site=]', function ($site) {
+        if ($site) {
+            if ($phpVersion = Site::customPhpVersion($site.'.'.data_get(Configuration::read(), 'tld'))) {
+                $phpVersion = PhpFpm::normalizePhpVersion($phpVersion);
+                return output($phpVersion);
+            }
+        } else {
+            $sites = PhpFpm::isolatedDirectories();
 
-        table(['Path', 'PHP Version'], $sites->all());
+            table(['Path', 'PHP Version'], $sites->all());
+        }
     })->descriptions('List all sites using isolated versions of PHP.');
 
     /**

--- a/cli/valet.php
+++ b/cli/valet.php
@@ -564,7 +564,7 @@ You might also want to investigate your global Composer configs. Helpful command
     /**
      * Get the PHP executable path for a site.
      */
-    $app->command('which-php [site] [--skip-cache]', function ($site, $skipCache) {
+    $app->command('which-php [site]', function ($site) {
         $host = Site::host($site ?: getcwd()).'.'.Configuration::read()['tld'];
         $phpVersion = Site::customPhpVersion($host);
 
@@ -577,10 +577,9 @@ You might also want to investigate your global Composer configs. Helpful command
 
         $phpVersion = $phpVersion ? PhpFpm::normalizePhpVersion($phpVersion) : null;
 
-        return output(Brew::whichPhp($phpVersion, $skipCache));
+        return output(Brew::getPhpExecutablePath($phpVersion));
     })->descriptions('Get the PHP executable path for a given site', [
         'site' => 'The site to get the PHP executable path for',
-        '--skip-cache' => 'Force re-check of the PHP executable path',
     ]);
 
     /**

--- a/cli/valet.php
+++ b/cli/valet.php
@@ -518,7 +518,7 @@ You might also want to investigate your global Composer configs. Helpful command
                 return info("Valet is already using {$linkedVersion}.");
             }
 
-            info("Found '{$site}' specifying version: {$phpVersion}");
+            info("Found '{$site}/.valetphprc' specifying version: {$phpVersion}");
         }
 
         PhpFpm::useVersion($phpVersion, $force);

--- a/cli/valet.php
+++ b/cli/valet.php
@@ -562,7 +562,7 @@ You might also want to investigate your global Composer configs. Helpful command
     })->descriptions('List all sites using isolated versions of PHP.');
 
     /**
-     * Get PHP Birnary
+     * Get PHP Executable
      */
     $app->command('which-php [site] [--skip-cache]', function ($site, $skipCache) {
         $host = Site::host($site ?: getcwd()).'.'.Configuration::read()['tld'];
@@ -578,24 +578,28 @@ You might also want to investigate your global Composer configs. Helpful command
         $phpVersion = $phpVersion ? PhpFpm::normalizePhpVersion($phpVersion) : null;
 
         return output(Brew::whichPhp($phpVersion, $skipCache));
-    })->descriptions('Get the PHP binary path for a given site', [
-        'site' => 'The site to get the PHP binary path for',
-        '--skip-cache' => 'Force a re-check of the PHP binary path',
+    })->descriptions('Get the PHP executable path for a given site', [
+        'site' => 'The site to get the PHP executable path for',
+        '--skip-cache' => 'Force re-check of the PHP executable path',
     ]);
 
     /**
-     * Proxy PHP Commands with correct version
+     * Proxy PHP commands with isolated site's  PHP executable
      */
-    $app->command('php', function () {
+    $app->command('php [command]', function ($command) {
         warning('It looks like you are running `cli/valet.php` directly; please use the `valet` script in the project root instead.');
-    })->descriptions('Proxy PHP Commands with isolated PHP version');
+    })->descriptions("Proxy PHP commands with isolated site's PHP executable",  [
+        'command' => "Command to run with isolated site's PHP executable",
+    ]);
 
     /**
-     * Proxy composer commands with the "php" binary on the isolated site
+     * Proxy Composer commands with isolated site's PHP executable
      */
-    $app->command('composer', function () {
+    $app->command('composer [command]', function ($command) {
         warning('It looks like you are running `cli/valet.php` directly; please use the `valet` script in the project root instead.');
-    })->descriptions('Proxy composer Commands with isolated PHP version');
+    })->descriptions("Proxy Composer commands with isolated site's PHP executable", [
+        'command' => "Composer command to run with isolated site's PHP executable",
+    ]);
 
     /**
      * Tail log file.

--- a/cli/valet.php
+++ b/cli/valet.php
@@ -575,8 +575,6 @@ You might also want to investigate your global Composer configs. Helpful command
             }
         }
 
-        $phpVersion = $phpVersion ? PhpFpm::normalizePhpVersion($phpVersion) : null;
-
         return output(Brew::getPhpExecutablePath($phpVersion));
     })->descriptions('Get the PHP executable path for a given site', [
         'site' => 'The site to get the PHP executable path for',

--- a/cli/valet.php
+++ b/cli/valet.php
@@ -534,7 +534,6 @@ You might also want to investigate your global Composer configs. Helpful command
             $site = basename(getcwd());
         }
 
-
         PhpFpm::isolateDirectory($site, $phpVersion);
     })->descriptions('Change the version of PHP used by Valet to serve the current working directory', [
         'phpVersion' => 'The PHP version you want to use; e.g php@8.1',

--- a/cli/valet.php
+++ b/cli/valet.php
@@ -534,10 +534,6 @@ You might also want to investigate your global Composer configs. Helpful command
             $site = basename(getcwd());
         }
 
-        if (! $phpVersion) {
-            $phpVersion = Site::phpRcVersion($site);
-            info("Found '{$site}' specifying version: {$phpVersion}");
-        }
 
         PhpFpm::isolateDirectory($site, $phpVersion);
     })->descriptions('Change the version of PHP used by Valet to serve the current working directory', [

--- a/cli/valet.php
+++ b/cli/valet.php
@@ -584,7 +584,7 @@ You might also want to investigate your global Composer configs. Helpful command
     ]);
 
     /**
-     * Proxy PHP commands with isolated site's  PHP executable.
+     * Proxy PHP commands with isolated site's  PHP executable file.
      */
     $app->command('php [command]', function ($command) {
         warning('It looks like you are running `cli/valet.php` directly; please use the `valet` script in the project root instead.');

--- a/cli/valet.php
+++ b/cli/valet.php
@@ -562,13 +562,13 @@ You might also want to investigate your global Composer configs. Helpful command
     })->descriptions('List all sites using isolated versions of PHP.');
 
     /**
-     * Get the PHP executable path for a site
+     * Get the PHP executable path for a site.
      */
     $app->command('which-php [site] [--skip-cache]', function ($site, $skipCache) {
         $host = Site::host($site ?: getcwd()).'.'.Configuration::read()['tld'];
         $phpVersion = Site::customPhpVersion($host);
 
-        if(! $phpVersion){
+        if (! $phpVersion) {
             $path = getcwd().'/.valetphprc';
             if (file_exists($path)) {
                 $phpVersion = trim(file_get_contents($path));
@@ -584,16 +584,16 @@ You might also want to investigate your global Composer configs. Helpful command
     ]);
 
     /**
-     * Proxy PHP commands with isolated site's  PHP executable
+     * Proxy PHP commands with isolated site's  PHP executable.
      */
     $app->command('php [command]', function ($command) {
         warning('It looks like you are running `cli/valet.php` directly; please use the `valet` script in the project root instead.');
-    })->descriptions("Proxy PHP commands with isolated site's PHP executable",  [
+    })->descriptions("Proxy PHP commands with isolated site's PHP executable", [
         'command' => "Command to run with isolated site's PHP executable",
     ]);
 
     /**
-     * Proxy Composer commands with isolated site's PHP executable
+     * Proxy Composer commands with isolated site's PHP executable.
      */
     $app->command('composer [command]', function ($command) {
         warning('It looks like you are running `cli/valet.php` directly; please use the `valet` script in the project root instead.');

--- a/cli/valet.php
+++ b/cli/valet.php
@@ -555,10 +555,16 @@ You might also want to investigate your global Composer configs. Helpful command
     /**
      * List isolated sites.
      */
-    $app->command('isolated [--site=]', function ($site) {
+    $app->command('isolated [--site=] [--binary]', function ($site, $binary) {
         if ($site) {
             if ($phpVersion = Site::customPhpVersion($site.'.'.data_get(Configuration::read(), 'tld'))) {
+
                 $phpVersion = PhpFpm::normalizePhpVersion($phpVersion);
+
+                if($binary){
+                    return output(Brew::getPhpBinaryPath($phpVersion));
+                }
+
                 return output($phpVersion);
             }
         } else {

--- a/cli/valet.php
+++ b/cli/valet.php
@@ -565,7 +565,7 @@ You might also want to investigate your global Composer configs. Helpful command
      * Get PHP Birnary
      */
     $app->command('which-php [site]', function ($site = null) {
-        $host = Site::host($site ? $site : getcwd()).'.'.Configuration::read()['tld'];
+        $host = Site::host($site ?: getcwd()).'.'.Configuration::read()['tld'];
         $phpVersion = Site::customPhpVersion($host);
 
         if(! $phpVersion){
@@ -576,6 +576,7 @@ You might also want to investigate your global Composer configs. Helpful command
         }
 
         $phpVersion = $phpVersion ? PhpFpm::normalizePhpVersion($phpVersion) : null;
+
         return output(Brew::getPhpBinaryPath($phpVersion));
     })->descriptions('Get the PHP binary path for a given site', [
         'site' => 'The site to get the PHP binary path for',

--- a/cli/valet.php
+++ b/cli/valet.php
@@ -562,7 +562,7 @@ You might also want to investigate your global Composer configs. Helpful command
     })->descriptions('List all sites using isolated versions of PHP.');
 
     /**
-     * Get  the PHP executable path for a site
+     * Get the PHP executable path for a site
      */
     $app->command('which-php [site] [--skip-cache]', function ($site, $skipCache) {
         $host = Site::host($site ?: getcwd()).'.'.Configuration::read()['tld'];

--- a/cli/valet.php
+++ b/cli/valet.php
@@ -514,7 +514,7 @@ You might also want to investigate your global Composer configs. Helpful command
                 return info("Valet is using {$linkedVersion}.");
             }
 
-            if ($linkedVersion == $phpVersion  && ! $force) {
+            if ($linkedVersion == $phpVersion && ! $force) {
                 return info("Valet is already using {$linkedVersion}.");
             }
 

--- a/cli/valet.php
+++ b/cli/valet.php
@@ -583,7 +583,7 @@ You might also want to investigate your global Composer configs. Helpful command
     ]);
 
     /**
-     * Proxy PHP commands with isolated site's  PHP executable file.
+     * Proxy commands through to an isolated site's version of PHP.
      */
     $app->command('php [command]', function ($command) {
         warning('It looks like you are running `cli/valet.php` directly; please use the `valet` script in the project root instead.');
@@ -592,7 +592,7 @@ You might also want to investigate your global Composer configs. Helpful command
     ]);
 
     /**
-     * Proxy Composer commands with isolated site's PHP executable.
+     * Proxy commands through to an isolated site's version of Composer.
      */
     $app->command('composer [command]', function ($command) {
         warning('It looks like you are running `cli/valet.php` directly; please use the `valet` script in the project root instead.');

--- a/cli/valet.php
+++ b/cli/valet.php
@@ -562,7 +562,7 @@ You might also want to investigate your global Composer configs. Helpful command
     })->descriptions('List all sites using isolated versions of PHP.');
 
     /**
-     * Get PHP Executable
+     * Get  the PHP executable path for a site
      */
     $app->command('which-php [site] [--skip-cache]', function ($site, $skipCache) {
         $host = Site::host($site ?: getcwd()).'.'.Configuration::read()['tld'];

--- a/cli/valet.php
+++ b/cli/valet.php
@@ -564,7 +564,7 @@ You might also want to investigate your global Composer configs. Helpful command
     /**
      * Get PHP Birnary
      */
-    $app->command('which-php [site]', function ($site = null) {
+    $app->command('which-php [site] [--skip-cache]', function ($site, $skipCache) {
         $host = Site::host($site ?: getcwd()).'.'.Configuration::read()['tld'];
         $phpVersion = Site::customPhpVersion($host);
 
@@ -577,9 +577,10 @@ You might also want to investigate your global Composer configs. Helpful command
 
         $phpVersion = $phpVersion ? PhpFpm::normalizePhpVersion($phpVersion) : null;
 
-        return output(Brew::getPhpBinaryPath($phpVersion));
+        return output(Brew::whichPhp($phpVersion, $skipCache));
     })->descriptions('Get the PHP binary path for a given site', [
         'site' => 'The site to get the PHP binary path for',
+        '--skip-cache' => 'Force a re-check of the PHP binary path',
     ]);
 
     /**

--- a/tests/BrewTest.php
+++ b/tests/BrewTest.php
@@ -400,44 +400,44 @@ class BrewTest extends Yoast\PHPUnitPolyfills\TestCases\TestCase
         // When there is no symlinked Valet PHP exists
         $brewMock = Mockery::mock(Brew::class, [
             Mockery::mock(CommandLine::class),
-            $files = Mockery::mock(Filesystem::class)
+            $files = Mockery::mock(Filesystem::class),
         ])->makePartial();
 
-        $files->shouldReceive('isLink')->once()->with(BREW_PREFIX."/bin/valetphp74")->andReturn(false);
-        $files->shouldReceive('symlinkAsUser')->once()->withArgs([BREW_PREFIX."/Cellar/php@7.4/7.4.6/bin/php", BREW_PREFIX."/bin/valetphp74"]);
-        $brewMock->shouldReceive('getPhpExecutablePath')->once()->with('php@7.4')->andReturn(BREW_PREFIX."/Cellar/php@7.4/7.4.6/bin/php");
+        $files->shouldReceive('isLink')->once()->with(BREW_PREFIX.'/bin/valetphp74')->andReturn(false);
+        $files->shouldReceive('symlinkAsUser')->once()->withArgs([BREW_PREFIX.'/Cellar/php@7.4/7.4.6/bin/php', BREW_PREFIX.'/bin/valetphp74']);
+        $brewMock->shouldReceive('getPhpExecutablePath')->once()->with('php@7.4')->andReturn(BREW_PREFIX.'/Cellar/php@7.4/7.4.6/bin/php');
 
-        $this->assertEquals(BREW_PREFIX."/Cellar/php@7.4/7.4.6/bin/php", $brewMock->whichPhp('php@7.4'));
+        $this->assertEquals(BREW_PREFIX.'/Cellar/php@7.4/7.4.6/bin/php', $brewMock->whichPhp('php@7.4'));
 
         // When there is a symlinked Valet PHP exists
         $brewMock = Mockery::mock(Brew::class, [
             Mockery::mock(CommandLine::class),
-            $files = Mockery::mock(Filesystem::class)
+            $files = Mockery::mock(Filesystem::class),
         ])->makePartial();
 
         $brewMock->shouldNotHaveReceived('getPhpExecutablePath');
-        $files->shouldReceive('isLink')->once()->with(BREW_PREFIX."/bin/valetphp81")->andReturn(true);
-        $files->shouldReceive('readLink')->once()->with(BREW_PREFIX."/bin/valetphp81")->andReturn(BREW_PREFIX."/Cellar/php@8.1/8.1.5/bin/php");
-        $files->shouldReceive('exists')->once()->with(BREW_PREFIX."/Cellar/php@8.1/8.1.5/bin/php")->andReturn(true);
+        $files->shouldReceive('isLink')->once()->with(BREW_PREFIX.'/bin/valetphp81')->andReturn(true);
+        $files->shouldReceive('readLink')->once()->with(BREW_PREFIX.'/bin/valetphp81')->andReturn(BREW_PREFIX.'/Cellar/php@8.1/8.1.5/bin/php');
+        $files->shouldReceive('exists')->once()->with(BREW_PREFIX.'/Cellar/php@8.1/8.1.5/bin/php')->andReturn(true);
         $files->shouldNotHaveReceived('symlinkAsUser');
 
-        $this->assertEquals(BREW_PREFIX."/Cellar/php@8.1/8.1.5/bin/php", $brewMock->whichPhp('php@8.1'));
+        $this->assertEquals(BREW_PREFIX.'/Cellar/php@8.1/8.1.5/bin/php', $brewMock->whichPhp('php@8.1'));
 
         // Check with $skipCache enabled
         $brewMock = Mockery::mock(Brew::class, [
             Mockery::mock(CommandLine::class),
-            $files = Mockery::mock(Filesystem::class)
+            $files = Mockery::mock(Filesystem::class),
         ])->makePartial();
 
-        $brewMock->shouldReceive('getPhpExecutablePath')->once()->with('php@7.4')->andReturn(BREW_PREFIX."/Cellar/php@7.4/7.4.6/bin/php");
-        $files->shouldReceive('symlinkAsUser')->once()->withArgs([BREW_PREFIX."/Cellar/php@7.4/7.4.6/bin/php", BREW_PREFIX."/bin/valetphp74"]);
+        $brewMock->shouldReceive('getPhpExecutablePath')->once()->with('php@7.4')->andReturn(BREW_PREFIX.'/Cellar/php@7.4/7.4.6/bin/php');
+        $files->shouldReceive('symlinkAsUser')->once()->withArgs([BREW_PREFIX.'/Cellar/php@7.4/7.4.6/bin/php', BREW_PREFIX.'/bin/valetphp74']);
 
-        $this->assertEquals(BREW_PREFIX."/Cellar/php@7.4/7.4.6/bin/php", $brewMock->whichPhp('php@7.4', true));
+        $this->assertEquals(BREW_PREFIX.'/Cellar/php@7.4/7.4.6/bin/php', $brewMock->whichPhp('php@7.4', true));
 
         // When no PHP Version is provided
         $brewMock = Mockery::mock(Brew::class, [
             Mockery::mock(CommandLine::class),
-            Mockery::mock(Filesystem::class)
+            Mockery::mock(Filesystem::class),
         ])->makePartial();
 
         $this->assertEquals(BREW_PREFIX.'/bin/php', $brewMock->whichPhp(null));
@@ -445,67 +445,67 @@ class BrewTest extends Yoast\PHPUnitPolyfills\TestCases\TestCase
 
     public function test_it_can_get_php_binary_path_from_php_version()
     {
-        // When brew info has `linked_keg` paramerter
+        // When brew info has `linked_keg` parameter
         $brewMock = Mockery::mock(Brew::class, [
             $cli = Mockery::mock(CommandLine::class),
-            $files = Mockery::mock(Filesystem::class)
+            $files = Mockery::mock(Filesystem::class),
         ])->makePartial();
 
-        $cli->shouldReceive('runAsUser')->once()->with("brew --cellar php@7.4")->andReturn(BREW_PREFIX."/Cellar/php@7.4");
-        $cli->shouldReceive('runAsUser')->once()->with("brew info --json php@7.4")->andReturn('[{"linked_keg":"7.4.6","installed":[{"version":"7.4.5"}]}]');
-        $files->shouldReceive('exists')->once()->with(BREW_PREFIX."/Cellar/php@7.4/7.4.6/bin/php")->andReturn(true);
+        $cli->shouldReceive('runAsUser')->once()->with('brew --cellar php@7.4')->andReturn(BREW_PREFIX.'/Cellar/php@7.4');
+        $cli->shouldReceive('runAsUser')->once()->with('brew info --json php@7.4')->andReturn('[{"linked_keg":"7.4.6","installed":[{"version":"7.4.5"}]}]');
+        $files->shouldReceive('exists')->once()->with(BREW_PREFIX.'/Cellar/php@7.4/7.4.6/bin/php')->andReturn(true);
 
-        $this->assertEquals(BREW_PREFIX."/Cellar/php@7.4/7.4.6/bin/php", $brewMock->getPhpExecutablePath('php@7.4'));
+        $this->assertEquals(BREW_PREFIX.'/Cellar/php@7.4/7.4.6/bin/php', $brewMock->getPhpExecutablePath('php@7.4'));
 
         // When brew info doesn't have `linked_keg`
         $brewMock = Mockery::mock(Brew::class, [
             $cli = Mockery::mock(CommandLine::class),
-            $files = Mockery::mock(Filesystem::class)
+            $files = Mockery::mock(Filesystem::class),
         ])->makePartial();
 
-        $cli->shouldReceive('runAsUser')->once()->with("brew --cellar php@8.0")->andReturn(BREW_PREFIX."/Cellar/php@8.0");
-        $cli->shouldReceive('runAsUser')->once()->with("brew info --json php@8.0")->andReturn('[{"installed":[{"version":"8.0.5"}]}]');
-        $files->shouldReceive('exists')->once()->with(BREW_PREFIX."/Cellar/php@8.0/8.0.5/bin/php")->andReturn(true);
+        $cli->shouldReceive('runAsUser')->once()->with('brew --cellar php@8.0')->andReturn(BREW_PREFIX.'/Cellar/php@8.0');
+        $cli->shouldReceive('runAsUser')->once()->with('brew info --json php@8.0')->andReturn('[{"installed":[{"version":"8.0.5"}]}]');
+        $files->shouldReceive('exists')->once()->with(BREW_PREFIX.'/Cellar/php@8.0/8.0.5/bin/php')->andReturn(true);
 
-        $this->assertEquals(BREW_PREFIX."/Cellar/php@8.0/8.0.5/bin/php", $brewMock->getPhpExecutablePath('php@8.0'));
+        $this->assertEquals(BREW_PREFIX.'/Cellar/php@8.0/8.0.5/bin/php', $brewMock->getPhpExecutablePath('php@8.0'));
 
         // When brew info has a version that was manually installed
         $brewMock = Mockery::mock(Brew::class, [
             $cli = Mockery::mock(CommandLine::class),
-            $files = Mockery::mock(Filesystem::class)
+            $files = Mockery::mock(Filesystem::class),
         ])->makePartial();
 
-        $cli->shouldReceive('runAsUser')->once()->with("brew --cellar php@8.1")->andReturn(BREW_PREFIX."/Cellar/php@8.1");
-        $cli->shouldReceive('runAsUser')->once()->with("brew info --json php@8.1")
+        $cli->shouldReceive('runAsUser')->once()->with('brew --cellar php@8.1')->andReturn(BREW_PREFIX.'/Cellar/php@8.1');
+        $cli->shouldReceive('runAsUser')->once()->with('brew info --json php@8.1')
             ->andReturn('[{"installed":[{"version":"8.1.1", "installed_as_dependency":true}, {"version":"8.1.2", "installed_as_dependency":false}]}]');
-        $files->shouldReceive('exists')->once()->with(BREW_PREFIX."/Cellar/php@8.1/8.1.2/bin/php")->andReturn(true);
+        $files->shouldReceive('exists')->once()->with(BREW_PREFIX.'/Cellar/php@8.1/8.1.2/bin/php')->andReturn(true);
 
-        $this->assertEquals(BREW_PREFIX."/Cellar/php@8.1/8.1.2/bin/php", $brewMock->getPhpExecutablePath('php@8.1'));
+        $this->assertEquals(BREW_PREFIX.'/Cellar/php@8.1/8.1.2/bin/php', $brewMock->getPhpExecutablePath('php@8.1'));
 
         // When brew info has no version that was installed manually, it should pick the last PHP version
         $brewMock = Mockery::mock(Brew::class, [
             $cli = Mockery::mock(CommandLine::class),
-            $files = Mockery::mock(Filesystem::class)
+            $files = Mockery::mock(Filesystem::class),
         ])->makePartial();
 
-        $cli->shouldReceive('runAsUser')->once()->with("brew --cellar php@7.4")->andReturn(BREW_PREFIX."/Cellar/php@7.4");
-        $cli->shouldReceive('runAsUser')->once()->with("brew info --json php@7.4")
+        $cli->shouldReceive('runAsUser')->once()->with('brew --cellar php@7.4')->andReturn(BREW_PREFIX.'/Cellar/php@7.4');
+        $cli->shouldReceive('runAsUser')->once()->with('brew info --json php@7.4')
             ->andReturn('[{"installed":[{"version":"7.4.1", "installed_as_dependency":false}, {"version":"7.4.3", "installed_as_dependency":false}]}]');
-        $files->shouldReceive('exists')->once()->with(BREW_PREFIX."/Cellar/php@7.4/7.4.3/bin/php")->andReturn(true);
+        $files->shouldReceive('exists')->once()->with(BREW_PREFIX.'/Cellar/php@7.4/7.4.3/bin/php')->andReturn(true);
 
-        $this->assertEquals(BREW_PREFIX."/Cellar/php@7.4/7.4.3/bin/php", $brewMock->getPhpExecutablePath('php@7.4'));
+        $this->assertEquals(BREW_PREFIX.'/Cellar/php@7.4/7.4.3/bin/php', $brewMock->getPhpExecutablePath('php@7.4'));
 
         // When user has installed directly though `shivammathur/homebrew-php`
         $brewMock = Mockery::mock(Brew::class, [
             $cli = Mockery::mock(CommandLine::class),
-            $files = Mockery::mock(Filesystem::class)
+            $files = Mockery::mock(Filesystem::class),
         ])->makePartial();
 
-        $cli->shouldReceive('runAsUser')->once()->with("brew --cellar php@7.4")->andReturn(BREW_PREFIX."/Cellar/php@7.4");
-        $cli->shouldReceive('runAsUser')->once()->with("brew info --json php@7.4")->andReturn(false);
-        $files->shouldReceive('exists')->once()->with(BREW_PREFIX."/opt/php@7.4/bin/php")->andReturn(true);
+        $cli->shouldReceive('runAsUser')->once()->with('brew --cellar php@7.4')->andReturn(BREW_PREFIX.'/Cellar/php@7.4');
+        $cli->shouldReceive('runAsUser')->once()->with('brew info --json php@7.4')->andReturn(false);
+        $files->shouldReceive('exists')->once()->with(BREW_PREFIX.'/opt/php@7.4/bin/php')->andReturn(true);
 
-        $this->assertEquals(BREW_PREFIX."/opt/php@7.4/bin/php", $brewMock->getPhpExecutablePath('php@7.4'));
+        $this->assertEquals(BREW_PREFIX.'/opt/php@7.4/bin/php', $brewMock->getPhpExecutablePath('php@7.4'));
     }
 
     /**

--- a/tests/BrewTest.php
+++ b/tests/BrewTest.php
@@ -395,6 +395,23 @@ class BrewTest extends Yoast\PHPUnitPolyfills\TestCases\TestCase
         $brewMock->restartLinkedPhp();
     }
 
+    public function test_it_can_get_php_binary_path_from_php_version()
+    {
+        $cli = Mockery::mock(CommandLine::class);
+        $cli->shouldReceive('runAsUser')->once()->with('brew info php@7.4 --json')
+            ->andReturn('[{"name":"php@7.4","full_name":"php@7.4","aliases":[],"versioned_formulae":[],"versions":{"stable":"7.4.5"},"installed":[{"version":"7.4.5"}]}]');
+        swap(CommandLine::class, $cli);
+
+        dd(resolve(Brew::class)->getPhpBinaryPath('php@7.4'));
+
+        // $cli = Mockery::mock(CommandLine::class);
+        // $cli->shouldReceive('runAsUser')->once()->with('brew info php --json')
+        //     ->andReturn('[{"name":"php","full_name":"php","aliases":["php@8.0"],"versioned_formulae":[],"versions":{"stable":"8.0.0"},"installed":[{"version":"8.0.0"}]}]');
+        // swap(CommandLine::class, $cli);
+        // $this->assertTrue(resolve(Brew::class)->installed('php'));
+    }
+
+
     /**
      * Provider of php links and their expected split matches.
      *

--- a/tests/BrewTest.php
+++ b/tests/BrewTest.php
@@ -397,70 +397,114 @@ class BrewTest extends Yoast\PHPUnitPolyfills\TestCases\TestCase
 
     public function test_it_can_get_php_binary_path_from_php_version_and_create_symblink()
     {
-        // Scenario when there is no linked Valet PHP exists
-        $brewMock = Mockery::mock(Brew::class, [Mockery::mock(CommandLine::class), $files = Mockery::mock(Filesystem::class)])->makePartial();
+        // Scenario when there is no symlinked Valet PHP exists
+        $brewMock = Mockery::mock(Brew::class, [
+            Mockery::mock(CommandLine::class),
+            $files = Mockery::mock(Filesystem::class)
+        ])->makePartial();
+
         $files->shouldReceive('isLink')->once()->with(BREW_PREFIX."/bin/valetphp74")->andReturn(false);
         $files->shouldReceive('symlinkAsUser')->once()->withArgs([BREW_PREFIX."/Cellar/php@7.4/7.4.6/bin/php", BREW_PREFIX."/bin/valetphp74"]);
         $brewMock->shouldReceive('getPhpBinaryPath')->once()->with('php@7.4')->andReturn(BREW_PREFIX."/Cellar/php@7.4/7.4.6/bin/php");
+
         $this->assertEquals(BREW_PREFIX."/Cellar/php@7.4/7.4.6/bin/php", $brewMock->whichPhp('php@7.4'));
 
-        // Scenario when there is a linked Valet PHP exists
-        $brewMock = Mockery::mock(Brew::class, [Mockery::mock(CommandLine::class), $files = Mockery::mock(Filesystem::class)])->makePartial();
+        // Scenario when there is a symlinked Valet PHP exists
+        $brewMock = Mockery::mock(Brew::class, [
+            Mockery::mock(CommandLine::class),
+            $files = Mockery::mock(Filesystem::class)
+        ])->makePartial();
+
         $brewMock->shouldNotHaveReceived('getPhpBinaryPath');
         $files->shouldReceive('isLink')->once()->with(BREW_PREFIX."/bin/valetphp81")->andReturn(true);
         $files->shouldReceive('readLink')->once()->with(BREW_PREFIX."/bin/valetphp81")->andReturn(BREW_PREFIX."/Cellar/php@8.1/8.1.5/bin/php");
         $files->shouldReceive('exists')->once()->with(BREW_PREFIX."/Cellar/php@8.1/8.1.5/bin/php")->andReturn(true);
         $files->shouldNotHaveReceived('symlinkAsUser');
+
         $this->assertEquals(BREW_PREFIX."/Cellar/php@8.1/8.1.5/bin/php", $brewMock->whichPhp('php@8.1'));
 
         // Check with $skipCache enabled
-        $brewMock = Mockery::mock(Brew::class, [Mockery::mock(CommandLine::class), $files = Mockery::mock(Filesystem::class)])->makePartial();
+        $brewMock = Mockery::mock(Brew::class, [
+            Mockery::mock(CommandLine::class),
+            $files = Mockery::mock(Filesystem::class)
+        ])->makePartial();
+
         $brewMock->shouldReceive('getPhpBinaryPath')->once()->with('php@7.4')->andReturn(BREW_PREFIX."/Cellar/php@7.4/7.4.6/bin/php");
         $files->shouldReceive('symlinkAsUser')->once()->withArgs([BREW_PREFIX."/Cellar/php@7.4/7.4.6/bin/php", BREW_PREFIX."/bin/valetphp74"]);
+
         $this->assertEquals(BREW_PREFIX."/Cellar/php@7.4/7.4.6/bin/php", $brewMock->whichPhp('php@7.4', true));
 
-        // Scenario when non PHP Version is proivided
-        $brewMock = Mockery::mock(Brew::class, [Mockery::mock(CommandLine::class),  Mockery::mock(Filesystem::class)])->makePartial();
+        // Scenario when no PHP Version is proivided
+        $brewMock = Mockery::mock(Brew::class, [
+            Mockery::mock(CommandLine::class),
+            Mockery::mock(Filesystem::class)
+        ])->makePartial();
+
         $this->assertEquals(BREW_PREFIX.'/bin/php', $brewMock->whichPhp(null));
     }
 
     public function test_it_can_get_php_binary_path_from_php_version()
     {
-        // linked_keg
-        $brewMock = Mockery::mock(Brew::class, [$cli = Mockery::mock(CommandLine::class), $files = Mockery::mock(Filesystem::class)])->makePartial();
+        // Scenario when brew info has `linked_keg`
+        $brewMock = Mockery::mock(Brew::class, [
+            $cli = Mockery::mock(CommandLine::class),
+            $files = Mockery::mock(Filesystem::class)
+        ])->makePartial();
+
         $cli->shouldReceive('runAsUser')->once()->with("brew --cellar php@7.4")->andReturn(BREW_PREFIX."/Cellar/php@7.4");
         $cli->shouldReceive('runAsUser')->once()->with("brew info --json php@7.4")->andReturn('[{"linked_keg":"7.4.6","installed":[{"version":"7.4.5"}]}]');
         $files->shouldReceive('exists')->once()->with(BREW_PREFIX."/Cellar/php@7.4/7.4.6/bin/php")->andReturn(true);
+
         $this->assertEquals(BREW_PREFIX."/Cellar/php@7.4/7.4.6/bin/php", $brewMock->getPhpBinaryPath('php@7.4'));
 
-        // no linked_keg
-        $brewMock = Mockery::mock(Brew::class, [$cli = Mockery::mock(CommandLine::class), $files = Mockery::mock(Filesystem::class)])->makePartial();
+        // Scenario when brew info doesn't have `linked_keg`
+        $brewMock = Mockery::mock(Brew::class, [
+            $cli = Mockery::mock(CommandLine::class),
+            $files = Mockery::mock(Filesystem::class)
+        ])->makePartial();
+
         $cli->shouldReceive('runAsUser')->once()->with("brew --cellar php@8.0")->andReturn(BREW_PREFIX."/Cellar/php@8.0");
         $cli->shouldReceive('runAsUser')->once()->with("brew info --json php@8.0")->andReturn('[{"installed":[{"version":"8.0.5"}]}]');
         $files->shouldReceive('exists')->once()->with(BREW_PREFIX."/Cellar/php@8.0/8.0.5/bin/php")->andReturn(true);
+
         $this->assertEquals(BREW_PREFIX."/Cellar/php@8.0/8.0.5/bin/php", $brewMock->getPhpBinaryPath('php@8.0'));
 
-        // installed_as_dependency
-        $brewMock = Mockery::mock(Brew::class, [$cli = Mockery::mock(CommandLine::class), $files = Mockery::mock(Filesystem::class)])->makePartial();
+        // Scenario when brew info has a version with that was not installed_as_dependency
+        $brewMock = Mockery::mock(Brew::class, [
+            $cli = Mockery::mock(CommandLine::class),
+            $files = Mockery::mock(Filesystem::class)
+        ])->makePartial();
+
         $cli->shouldReceive('runAsUser')->once()->with("brew --cellar php@8.1")->andReturn(BREW_PREFIX."/Cellar/php@8.1");
         $cli->shouldReceive('runAsUser')->once()->with("brew info --json php@8.1")
             ->andReturn('[{"installed":[{"version":"8.1.1", "installed_as_dependency":true}, {"version":"8.1.2", "installed_as_dependency":false}]}]');
         $files->shouldReceive('exists')->once()->with(BREW_PREFIX."/Cellar/php@8.1/8.1.2/bin/php")->andReturn(true);
+
         $this->assertEquals(BREW_PREFIX."/Cellar/php@8.1/8.1.2/bin/php", $brewMock->getPhpBinaryPath('php@8.1'));
 
-        // installed_as_dependency 2
-        $brewMock = Mockery::mock(Brew::class, [$cli = Mockery::mock(CommandLine::class), $files = Mockery::mock(Filesystem::class)])->makePartial();
+        // Scenario when brew info has no version that was installed manually, it should pick the last PHP version
+        $brewMock = Mockery::mock(Brew::class, [
+            $cli = Mockery::mock(CommandLine::class),
+            $files = Mockery::mock(Filesystem::class)
+        ])->makePartial();
+
         $cli->shouldReceive('runAsUser')->once()->with("brew --cellar php@7.4")->andReturn(BREW_PREFIX."/Cellar/php@7.4");
         $cli->shouldReceive('runAsUser')->once()->with("brew info --json php@7.4")
             ->andReturn('[{"installed":[{"version":"7.4.1", "installed_as_dependency":false}, {"version":"7.4.3", "installed_as_dependency":false}]}]');
         $files->shouldReceive('exists')->once()->with(BREW_PREFIX."/Cellar/php@7.4/7.4.3/bin/php")->andReturn(true);
+
         $this->assertEquals(BREW_PREFIX."/Cellar/php@7.4/7.4.3/bin/php", $brewMock->getPhpBinaryPath('php@7.4'));
 
         // Scenario when user has installed directly though shivammathur/homebrew-php
-        $brewMock = Mockery::mock(Brew::class, [$cli = Mockery::mock(CommandLine::class), $files = Mockery::mock(Filesystem::class)])->makePartial();
+        $brewMock = Mockery::mock(Brew::class, [
+            $cli = Mockery::mock(CommandLine::class),
+            $files = Mockery::mock(Filesystem::class)
+        ])->makePartial();
+
         $cli->shouldReceive('runAsUser')->once()->with("brew --cellar php@7.4")->andReturn(BREW_PREFIX."/Cellar/php@7.4");
         $cli->shouldReceive('runAsUser')->once()->with("brew info --json php@7.4")->andReturn(false);
         $files->shouldReceive('exists')->once()->with(BREW_PREFIX."/opt/php@7.4/bin/php")->andReturn(true);
+
         $this->assertEquals(BREW_PREFIX."/opt/php@7.4/bin/php", $brewMock->getPhpBinaryPath('php@7.4'));
     }
 

--- a/tests/BrewTest.php
+++ b/tests/BrewTest.php
@@ -409,7 +409,7 @@ class BrewTest extends Yoast\PHPUnitPolyfills\TestCases\TestCase
 
         $this->assertEquals(BREW_PREFIX.'/Cellar/php@7.4/7.4.6/bin/php', $brewMock->whichPhp('php@7.4'));
 
-        // When there is a symlinked Valet PHP exists
+        // When a symlinked Valet PHP exists
         $brewMock = Mockery::mock(Brew::class, [
             Mockery::mock(CommandLine::class),
             $files = Mockery::mock(Filesystem::class),

--- a/tests/BrewTest.php
+++ b/tests/BrewTest.php
@@ -397,7 +397,7 @@ class BrewTest extends Yoast\PHPUnitPolyfills\TestCases\TestCase
 
     public function test_it_can_get_php_binary_path_from_php_version_and_create_symlink()
     {
-        // Scenario when there is no symlinked Valet PHP exists
+        // When there is no symlinked Valet PHP exists
         $brewMock = Mockery::mock(Brew::class, [
             Mockery::mock(CommandLine::class),
             $files = Mockery::mock(Filesystem::class)
@@ -409,7 +409,7 @@ class BrewTest extends Yoast\PHPUnitPolyfills\TestCases\TestCase
 
         $this->assertEquals(BREW_PREFIX."/Cellar/php@7.4/7.4.6/bin/php", $brewMock->whichPhp('php@7.4'));
 
-        // Scenario when there is a symlinked Valet PHP exists
+        // When there is a symlinked Valet PHP exists
         $brewMock = Mockery::mock(Brew::class, [
             Mockery::mock(CommandLine::class),
             $files = Mockery::mock(Filesystem::class)
@@ -434,7 +434,7 @@ class BrewTest extends Yoast\PHPUnitPolyfills\TestCases\TestCase
 
         $this->assertEquals(BREW_PREFIX."/Cellar/php@7.4/7.4.6/bin/php", $brewMock->whichPhp('php@7.4', true));
 
-        // Scenario when no PHP Version is proivided
+        // When no PHP Version is provided
         $brewMock = Mockery::mock(Brew::class, [
             Mockery::mock(CommandLine::class),
             Mockery::mock(Filesystem::class)
@@ -445,7 +445,7 @@ class BrewTest extends Yoast\PHPUnitPolyfills\TestCases\TestCase
 
     public function test_it_can_get_php_binary_path_from_php_version()
     {
-        // Scenario when brew info has `linked_keg`
+        // When brew info has `linked_keg` paramert
         $brewMock = Mockery::mock(Brew::class, [
             $cli = Mockery::mock(CommandLine::class),
             $files = Mockery::mock(Filesystem::class)
@@ -457,7 +457,7 @@ class BrewTest extends Yoast\PHPUnitPolyfills\TestCases\TestCase
 
         $this->assertEquals(BREW_PREFIX."/Cellar/php@7.4/7.4.6/bin/php", $brewMock->getPhpExecutablePath('php@7.4'));
 
-        // Scenario when brew info doesn't have `linked_keg`
+        // When brew info doesn't have `linked_keg`
         $brewMock = Mockery::mock(Brew::class, [
             $cli = Mockery::mock(CommandLine::class),
             $files = Mockery::mock(Filesystem::class)
@@ -469,7 +469,7 @@ class BrewTest extends Yoast\PHPUnitPolyfills\TestCases\TestCase
 
         $this->assertEquals(BREW_PREFIX."/Cellar/php@8.0/8.0.5/bin/php", $brewMock->getPhpExecutablePath('php@8.0'));
 
-        // Scenario when brew info has a version with that was not installed_as_dependency
+        // When brew info has a version that was manually installed
         $brewMock = Mockery::mock(Brew::class, [
             $cli = Mockery::mock(CommandLine::class),
             $files = Mockery::mock(Filesystem::class)
@@ -482,7 +482,7 @@ class BrewTest extends Yoast\PHPUnitPolyfills\TestCases\TestCase
 
         $this->assertEquals(BREW_PREFIX."/Cellar/php@8.1/8.1.2/bin/php", $brewMock->getPhpExecutablePath('php@8.1'));
 
-        // Scenario when brew info has no version that was installed manually, it should pick the last PHP version
+        // When brew info has no version that was installed manually, it should pick the last PHP version
         $brewMock = Mockery::mock(Brew::class, [
             $cli = Mockery::mock(CommandLine::class),
             $files = Mockery::mock(Filesystem::class)
@@ -495,7 +495,7 @@ class BrewTest extends Yoast\PHPUnitPolyfills\TestCases\TestCase
 
         $this->assertEquals(BREW_PREFIX."/Cellar/php@7.4/7.4.3/bin/php", $brewMock->getPhpExecutablePath('php@7.4'));
 
-        // Scenario when user has installed directly though shivammathur/homebrew-php
+        // When user has installed directly though `shivammathur/homebrew-php`
         $brewMock = Mockery::mock(Brew::class, [
             $cli = Mockery::mock(CommandLine::class),
             $files = Mockery::mock(Filesystem::class)

--- a/tests/BrewTest.php
+++ b/tests/BrewTest.php
@@ -395,7 +395,7 @@ class BrewTest extends Yoast\PHPUnitPolyfills\TestCases\TestCase
         $brewMock->restartLinkedPhp();
     }
 
-    public function test_it_can_get_php_binary_path_from_php_version_and_create_symblink()
+    public function test_it_can_get_php_binary_path_from_php_version_and_create_symlink()
     {
         // Scenario when there is no symlinked Valet PHP exists
         $brewMock = Mockery::mock(Brew::class, [
@@ -405,7 +405,7 @@ class BrewTest extends Yoast\PHPUnitPolyfills\TestCases\TestCase
 
         $files->shouldReceive('isLink')->once()->with(BREW_PREFIX."/bin/valetphp74")->andReturn(false);
         $files->shouldReceive('symlinkAsUser')->once()->withArgs([BREW_PREFIX."/Cellar/php@7.4/7.4.6/bin/php", BREW_PREFIX."/bin/valetphp74"]);
-        $brewMock->shouldReceive('getPhpBinaryPath')->once()->with('php@7.4')->andReturn(BREW_PREFIX."/Cellar/php@7.4/7.4.6/bin/php");
+        $brewMock->shouldReceive('getPhpExecutablePath')->once()->with('php@7.4')->andReturn(BREW_PREFIX."/Cellar/php@7.4/7.4.6/bin/php");
 
         $this->assertEquals(BREW_PREFIX."/Cellar/php@7.4/7.4.6/bin/php", $brewMock->whichPhp('php@7.4'));
 
@@ -415,7 +415,7 @@ class BrewTest extends Yoast\PHPUnitPolyfills\TestCases\TestCase
             $files = Mockery::mock(Filesystem::class)
         ])->makePartial();
 
-        $brewMock->shouldNotHaveReceived('getPhpBinaryPath');
+        $brewMock->shouldNotHaveReceived('getPhpExecutablePath');
         $files->shouldReceive('isLink')->once()->with(BREW_PREFIX."/bin/valetphp81")->andReturn(true);
         $files->shouldReceive('readLink')->once()->with(BREW_PREFIX."/bin/valetphp81")->andReturn(BREW_PREFIX."/Cellar/php@8.1/8.1.5/bin/php");
         $files->shouldReceive('exists')->once()->with(BREW_PREFIX."/Cellar/php@8.1/8.1.5/bin/php")->andReturn(true);
@@ -429,7 +429,7 @@ class BrewTest extends Yoast\PHPUnitPolyfills\TestCases\TestCase
             $files = Mockery::mock(Filesystem::class)
         ])->makePartial();
 
-        $brewMock->shouldReceive('getPhpBinaryPath')->once()->with('php@7.4')->andReturn(BREW_PREFIX."/Cellar/php@7.4/7.4.6/bin/php");
+        $brewMock->shouldReceive('getPhpExecutablePath')->once()->with('php@7.4')->andReturn(BREW_PREFIX."/Cellar/php@7.4/7.4.6/bin/php");
         $files->shouldReceive('symlinkAsUser')->once()->withArgs([BREW_PREFIX."/Cellar/php@7.4/7.4.6/bin/php", BREW_PREFIX."/bin/valetphp74"]);
 
         $this->assertEquals(BREW_PREFIX."/Cellar/php@7.4/7.4.6/bin/php", $brewMock->whichPhp('php@7.4', true));
@@ -455,7 +455,7 @@ class BrewTest extends Yoast\PHPUnitPolyfills\TestCases\TestCase
         $cli->shouldReceive('runAsUser')->once()->with("brew info --json php@7.4")->andReturn('[{"linked_keg":"7.4.6","installed":[{"version":"7.4.5"}]}]');
         $files->shouldReceive('exists')->once()->with(BREW_PREFIX."/Cellar/php@7.4/7.4.6/bin/php")->andReturn(true);
 
-        $this->assertEquals(BREW_PREFIX."/Cellar/php@7.4/7.4.6/bin/php", $brewMock->getPhpBinaryPath('php@7.4'));
+        $this->assertEquals(BREW_PREFIX."/Cellar/php@7.4/7.4.6/bin/php", $brewMock->getPhpExecutablePath('php@7.4'));
 
         // Scenario when brew info doesn't have `linked_keg`
         $brewMock = Mockery::mock(Brew::class, [
@@ -467,7 +467,7 @@ class BrewTest extends Yoast\PHPUnitPolyfills\TestCases\TestCase
         $cli->shouldReceive('runAsUser')->once()->with("brew info --json php@8.0")->andReturn('[{"installed":[{"version":"8.0.5"}]}]');
         $files->shouldReceive('exists')->once()->with(BREW_PREFIX."/Cellar/php@8.0/8.0.5/bin/php")->andReturn(true);
 
-        $this->assertEquals(BREW_PREFIX."/Cellar/php@8.0/8.0.5/bin/php", $brewMock->getPhpBinaryPath('php@8.0'));
+        $this->assertEquals(BREW_PREFIX."/Cellar/php@8.0/8.0.5/bin/php", $brewMock->getPhpExecutablePath('php@8.0'));
 
         // Scenario when brew info has a version with that was not installed_as_dependency
         $brewMock = Mockery::mock(Brew::class, [
@@ -480,7 +480,7 @@ class BrewTest extends Yoast\PHPUnitPolyfills\TestCases\TestCase
             ->andReturn('[{"installed":[{"version":"8.1.1", "installed_as_dependency":true}, {"version":"8.1.2", "installed_as_dependency":false}]}]');
         $files->shouldReceive('exists')->once()->with(BREW_PREFIX."/Cellar/php@8.1/8.1.2/bin/php")->andReturn(true);
 
-        $this->assertEquals(BREW_PREFIX."/Cellar/php@8.1/8.1.2/bin/php", $brewMock->getPhpBinaryPath('php@8.1'));
+        $this->assertEquals(BREW_PREFIX."/Cellar/php@8.1/8.1.2/bin/php", $brewMock->getPhpExecutablePath('php@8.1'));
 
         // Scenario when brew info has no version that was installed manually, it should pick the last PHP version
         $brewMock = Mockery::mock(Brew::class, [
@@ -493,7 +493,7 @@ class BrewTest extends Yoast\PHPUnitPolyfills\TestCases\TestCase
             ->andReturn('[{"installed":[{"version":"7.4.1", "installed_as_dependency":false}, {"version":"7.4.3", "installed_as_dependency":false}]}]');
         $files->shouldReceive('exists')->once()->with(BREW_PREFIX."/Cellar/php@7.4/7.4.3/bin/php")->andReturn(true);
 
-        $this->assertEquals(BREW_PREFIX."/Cellar/php@7.4/7.4.3/bin/php", $brewMock->getPhpBinaryPath('php@7.4'));
+        $this->assertEquals(BREW_PREFIX."/Cellar/php@7.4/7.4.3/bin/php", $brewMock->getPhpExecutablePath('php@7.4'));
 
         // Scenario when user has installed directly though shivammathur/homebrew-php
         $brewMock = Mockery::mock(Brew::class, [
@@ -505,7 +505,7 @@ class BrewTest extends Yoast\PHPUnitPolyfills\TestCases\TestCase
         $cli->shouldReceive('runAsUser')->once()->with("brew info --json php@7.4")->andReturn(false);
         $files->shouldReceive('exists')->once()->with(BREW_PREFIX."/opt/php@7.4/bin/php")->andReturn(true);
 
-        $this->assertEquals(BREW_PREFIX."/opt/php@7.4/bin/php", $brewMock->getPhpBinaryPath('php@7.4'));
+        $this->assertEquals(BREW_PREFIX."/opt/php@7.4/bin/php", $brewMock->getPhpExecutablePath('php@7.4'));
     }
 
     /**

--- a/tests/BrewTest.php
+++ b/tests/BrewTest.php
@@ -445,7 +445,7 @@ class BrewTest extends Yoast\PHPUnitPolyfills\TestCases\TestCase
 
     public function test_it_can_get_php_binary_path_from_php_version()
     {
-        // When brew info has `linked_keg` paramert
+        // When brew info has `linked_keg` paramerter
         $brewMock = Mockery::mock(Brew::class, [
             $cli = Mockery::mock(CommandLine::class),
             $files = Mockery::mock(Filesystem::class)

--- a/tests/BrewTest.php
+++ b/tests/BrewTest.php
@@ -452,12 +452,12 @@ class BrewTest extends Yoast\PHPUnitPolyfills\TestCases\TestCase
 
     public function test_it_can_compare_two_php_versions()
     {
-        $this->assertTrue(resolve(Brew::class)->isPhpVersionsEqual('php71', 'php@7.1'));
-        $this->assertTrue(resolve(Brew::class)->isPhpVersionsEqual('php71', 'php@71'));
-        $this->assertTrue(resolve(Brew::class)->isPhpVersionsEqual('php71', '71'));
+        $this->assertTrue(resolve(Brew::class)->arePhpVersionsEqual('php71', 'php@7.1'));
+        $this->assertTrue(resolve(Brew::class)->arePhpVersionsEqual('php71', 'php@71'));
+        $this->assertTrue(resolve(Brew::class)->arePhpVersionsEqual('php71', '71'));
 
-        $this->assertFalse(resolve(Brew::class)->isPhpVersionsEqual('php71', 'php@70'));
-        $this->assertFalse(resolve(Brew::class)->isPhpVersionsEqual('php71', '72'));
+        $this->assertFalse(resolve(Brew::class)->arePhpVersionsEqual('php71', 'php@70'));
+        $this->assertFalse(resolve(Brew::class)->arePhpVersionsEqual('php71', '72'));
     }
 
     /**

--- a/tests/BrewTest.php
+++ b/tests/BrewTest.php
@@ -400,37 +400,37 @@ class BrewTest extends Yoast\PHPUnitPolyfills\TestCases\TestCase
         // Scenario when there is no linked valet php exists
         $files = Mockery::mock(Filesystem::class);
         $cli = Mockery::mock(CommandLine::class);
-        $files->shouldReceive('isLink')->once()->with(BREW_PREFIX. "/bin/valetphp74")->andReturn(false);
-        $cli->shouldReceive('runAsUser')->once()->with("brew --cellar php@7.4")->andReturn("/opt/homebrew/Cellar/php@7.4");
+        $files->shouldReceive('isLink')->once()->with(BREW_PREFIX."/bin/valetphp74")->andReturn(false);
+        $cli->shouldReceive('runAsUser')->once()->with("brew --cellar php@7.4")->andReturn(BREW_PREFIX."/Cellar/php@7.4");
         $cli->shouldReceive('runAsUser')->once()->with("brew info --json php@7.4")->andReturn('[{"linked_keg":"7.4.6","installed":[{"version":"7.4.5"}]}]');
-        $files->shouldReceive('exists')->once()->with("/opt/homebrew/Cellar/php@7.4/7.4.6/bin/php")->andReturn(true);
-        $files->shouldReceive('symlinkAsUser')->once()->withArgs(["/opt/homebrew/Cellar/php@7.4/7.4.6/bin/php", BREW_PREFIX."/bin/valetphp74"]);
+        $files->shouldReceive('exists')->once()->with(BREW_PREFIX."/Cellar/php@7.4/7.4.6/bin/php")->andReturn(true);
+        $files->shouldReceive('symlinkAsUser')->once()->withArgs([BREW_PREFIX."/Cellar/php@7.4/7.4.6/bin/php", BREW_PREFIX."/bin/valetphp74"]);
         swap(CommandLine::class, $cli);
         swap(Filesystem::class, $files);
-        $this->assertEquals("/opt/homebrew/Cellar/php@7.4/7.4.6/bin/php", resolve(Brew::class)->getPhpBinaryPath('php@7.4'));
+        $this->assertEquals(BREW_PREFIX."/Cellar/php@7.4/7.4.6/bin/php", resolve(Brew::class)->getPhpBinaryPath('php@7.4'));
 
         // Scenario when user has installed directly though shivammathur/homebrew-php
         $files = Mockery::mock(Filesystem::class);
         $cli = Mockery::mock(CommandLine::class);
-        $files->shouldReceive('isLink')->once()->with(BREW_PREFIX. "/bin/valetphp74")->andReturn(false);
-        $cli->shouldReceive('runAsUser')->once()->with("brew --cellar php@7.4")->andReturn("/opt/homebrew/Cellar/php@7.4");
+        $files->shouldReceive('isLink')->once()->with(BREW_PREFIX."/bin/valetphp74")->andReturn(false);
+        $cli->shouldReceive('runAsUser')->once()->with("brew --cellar php@7.4")->andReturn(BREW_PREFIX."/Cellar/php@7.4");
         $cli->shouldReceive('runAsUser')->once()->with("brew info --json php@7.4")->andReturn('[{"installed":[{"version":"7.4.5"}]}]');
-        $files->shouldReceive('exists')->once()->with("/opt/homebrew/Cellar/php@7.4/7.4.5/bin/php")->andReturn(false);
+        $files->shouldReceive('exists')->once()->with(BREW_PREFIX."/Cellar/php@7.4/7.4.5/bin/php")->andReturn(false);
         $files->shouldReceive('exists')->once()->with(BREW_PREFIX."/opt/php@7.4/bin/php")->andReturn(true);
-        $files->shouldReceive('symlinkAsUser')->once()->withArgs(["/opt/homebrew/opt/php@7.4/bin/php", BREW_PREFIX."/bin/valetphp74"]);
+        $files->shouldReceive('symlinkAsUser')->once()->withArgs([BREW_PREFIX ."/opt/php@7.4/bin/php", BREW_PREFIX."/bin/valetphp74"]);
         swap(CommandLine::class, $cli);
         swap(Filesystem::class, $files);
-        $this->assertEquals("/opt/homebrew/opt/php@7.4/bin/php", resolve(Brew::class)->getPhpBinaryPath('php@7.4'));
+        $this->assertEquals(BREW_PREFIX ."/opt/php@7.4/bin/php", resolve(Brew::class)->getPhpBinaryPath('php@7.4'));
 
         // Scenario when there is a linked valet php exists
         $files = Mockery::mock(Filesystem::class);
         $cli = Mockery::mock(CommandLine::class);
-        $files->shouldReceive('isLink')->once()->with(BREW_PREFIX. "/bin/valetphp74")->andReturn(true);
-        $files->shouldReceive('readLink')->once()->with(BREW_PREFIX. "/bin/valetphp74")->andReturn("/opt/homebrew/Cellar/php@7.4/7.4.5/bin/php");
-        $files->shouldReceive('exists')->once()->with("/opt/homebrew/Cellar/php@7.4/7.4.5/bin/php")->andReturn(true);
+        $files->shouldReceive('isLink')->once()->with(BREW_PREFIX."/bin/valetphp74")->andReturn(true);
+        $files->shouldReceive('readLink')->once()->with(BREW_PREFIX."/bin/valetphp74")->andReturn(BREW_PREFIX."/Cellar/php@7.4/7.4.5/bin/php");
+        $files->shouldReceive('exists')->once()->with(BREW_PREFIX."/Cellar/php@7.4/7.4.5/bin/php")->andReturn(true);
         swap(CommandLine::class, $cli);
         swap(Filesystem::class, $files);
-        $this->assertEquals(BREW_PREFIX. "/bin/valetphp74", resolve(Brew::class)->getPhpBinaryPath('php@7.4'));
+        $this->assertEquals(BREW_PREFIX."/bin/valetphp74", resolve(Brew::class)->getPhpBinaryPath('php@7.4'));
 
         // Scenario when non php version is proivided
         $files = Mockery::mock(Filesystem::class);

--- a/tests/BrewTest.php
+++ b/tests/BrewTest.php
@@ -395,44 +395,51 @@ class BrewTest extends Yoast\PHPUnitPolyfills\TestCases\TestCase
         $brewMock->restartLinkedPhp();
     }
 
-    public function test_it_can_get_php_binary_path_from_php_version_and_create_symlink()
+    public function test_it_can_get_php_binary_path_from_php_version()
     {
-        // When there is no symlinked Valet PHP exists
+        // Check the default `/opt/homebrew/opt/php@8.1/bin/php` location first
         $brewMock = Mockery::mock(Brew::class, [
             Mockery::mock(CommandLine::class),
             $files = Mockery::mock(Filesystem::class),
         ])->makePartial();
 
-        $files->shouldReceive('isLink')->once()->with(BREW_PREFIX.'/bin/valetphp74')->andReturn(false);
-        $files->shouldReceive('symlinkAsUser')->once()->withArgs([BREW_PREFIX.'/Cellar/php@7.4/7.4.6/bin/php', BREW_PREFIX.'/bin/valetphp74']);
-        $brewMock->shouldReceive('getPhpExecutablePath')->once()->with('php@7.4')->andReturn(BREW_PREFIX.'/Cellar/php@7.4/7.4.6/bin/php');
+        $files->shouldReceive('exists')->once()->with(BREW_PREFIX.'/opt/php@7.4/bin/php')->andReturn(true);
+        $files->shouldNotReceive('exists')->with(BREW_PREFIX.'/opt/php@74/bin/php');
+        $this->assertEquals(BREW_PREFIX.'/opt/php@7.4/bin/php', $brewMock->getPhpExecutablePath('php@7.4'));
 
-        $this->assertEquals(BREW_PREFIX.'/Cellar/php@7.4/7.4.6/bin/php', $brewMock->whichPhp('php@7.4'));
-
-        // When a symlinked Valet PHP exists
+        // Check the `/opt/homebrew/opt/php71/bin/php` location for older installations
         $brewMock = Mockery::mock(Brew::class, [
             Mockery::mock(CommandLine::class),
             $files = Mockery::mock(Filesystem::class),
         ])->makePartial();
 
-        $brewMock->shouldNotHaveReceived('getPhpExecutablePath');
-        $files->shouldReceive('isLink')->once()->with(BREW_PREFIX.'/bin/valetphp81')->andReturn(true);
-        $files->shouldReceive('readLink')->once()->with(BREW_PREFIX.'/bin/valetphp81')->andReturn(BREW_PREFIX.'/Cellar/php@8.1/8.1.5/bin/php');
-        $files->shouldReceive('exists')->once()->with(BREW_PREFIX.'/Cellar/php@8.1/8.1.5/bin/php')->andReturn(true);
-        $files->shouldNotHaveReceived('symlinkAsUser');
+        $files->shouldReceive('exists')->once()->with(BREW_PREFIX.'/opt/php@7.4/bin/php')->andReturn(false);
+        $files->shouldReceive('exists')->with(BREW_PREFIX.'/opt/php74/bin/php')->andReturn(true);
+        $this->assertEquals(BREW_PREFIX.'/opt/php74/bin/php', $brewMock->getPhpExecutablePath('php@7.4'));
 
-        $this->assertEquals(BREW_PREFIX.'/Cellar/php@8.1/8.1.5/bin/php', $brewMock->whichPhp('php@8.1'));
-
-        // Check with $skipCache enabled
+        // When the default PHP is the version we are looking for
         $brewMock = Mockery::mock(Brew::class, [
             Mockery::mock(CommandLine::class),
             $files = Mockery::mock(Filesystem::class),
         ])->makePartial();
 
-        $brewMock->shouldReceive('getPhpExecutablePath')->once()->with('php@7.4')->andReturn(BREW_PREFIX.'/Cellar/php@7.4/7.4.6/bin/php');
-        $files->shouldReceive('symlinkAsUser')->once()->withArgs([BREW_PREFIX.'/Cellar/php@7.4/7.4.6/bin/php', BREW_PREFIX.'/bin/valetphp74']);
+        $files->shouldReceive('exists')->once()->with(BREW_PREFIX.'/opt/php@7.4/bin/php')->andReturn(false);
+        $files->shouldReceive('exists')->with(BREW_PREFIX.'/opt/php74/bin/php')->andReturn(false);
+        $files->shouldReceive('isLink')->with(BREW_PREFIX."/opt/php")->andReturn(true);
+        $files->shouldReceive('readLink')->with(BREW_PREFIX."/opt/php")->andReturn('../Cellar/php@7.4/7.4.13/bin/php');
+        $this->assertEquals(BREW_PREFIX."/opt/php/bin/php", $brewMock->getPhpExecutablePath('php@7.4'));
 
-        $this->assertEquals(BREW_PREFIX.'/Cellar/php@7.4/7.4.6/bin/php', $brewMock->whichPhp('php@7.4', true));
+        // When the default PHP is not the version we are looking for
+        $brewMock = Mockery::mock(Brew::class, [
+            Mockery::mock(CommandLine::class),
+            $files = Mockery::mock(Filesystem::class),
+        ])->makePartial();
+
+        $files->shouldReceive('exists')->once()->with(BREW_PREFIX.'/opt/php@7.4/bin/php')->andReturn(false);
+        $files->shouldReceive('exists')->with(BREW_PREFIX.'/opt/php74/bin/php')->andReturn(false);
+        $files->shouldReceive('isLink')->with(BREW_PREFIX."/opt/php")->andReturn(true);
+        $files->shouldReceive('readLink')->with(BREW_PREFIX."/opt/php")->andReturn('../Cellar/php@8.1/8.1.13/bin/php');
+        $this->assertEquals(BREW_PREFIX."/bin/php", $brewMock->getPhpExecutablePath('php@7.4')); // Could not find a version, so retuned the default binary
 
         // When no PHP Version is provided
         $brewMock = Mockery::mock(Brew::class, [
@@ -440,72 +447,17 @@ class BrewTest extends Yoast\PHPUnitPolyfills\TestCases\TestCase
             Mockery::mock(Filesystem::class),
         ])->makePartial();
 
-        $this->assertEquals(BREW_PREFIX.'/bin/php', $brewMock->whichPhp(null));
+        $this->assertEquals(BREW_PREFIX.'/bin/php', $brewMock->getPhpExecutablePath(null));
     }
 
-    public function test_it_can_get_php_binary_path_from_php_version()
+    public function test_it_can_compare_two_php_versions()
     {
-        // When brew info has `linked_keg` parameter
-        $brewMock = Mockery::mock(Brew::class, [
-            $cli = Mockery::mock(CommandLine::class),
-            $files = Mockery::mock(Filesystem::class),
-        ])->makePartial();
+        $this->assertTrue(resolve(Brew::class)->isPhpVersionsEqual('php71', 'php@7.1'));
+        $this->assertTrue(resolve(Brew::class)->isPhpVersionsEqual('php71', 'php@71'));
+        $this->assertTrue(resolve(Brew::class)->isPhpVersionsEqual('php71', '71'));
 
-        $cli->shouldReceive('runAsUser')->once()->with('brew --cellar php@7.4')->andReturn(BREW_PREFIX.'/Cellar/php@7.4');
-        $cli->shouldReceive('runAsUser')->once()->with('brew info --json php@7.4')->andReturn('[{"linked_keg":"7.4.6","installed":[{"version":"7.4.5"}]}]');
-        $files->shouldReceive('exists')->once()->with(BREW_PREFIX.'/Cellar/php@7.4/7.4.6/bin/php')->andReturn(true);
-
-        $this->assertEquals(BREW_PREFIX.'/Cellar/php@7.4/7.4.6/bin/php', $brewMock->getPhpExecutablePath('php@7.4'));
-
-        // When brew info doesn't have `linked_keg`
-        $brewMock = Mockery::mock(Brew::class, [
-            $cli = Mockery::mock(CommandLine::class),
-            $files = Mockery::mock(Filesystem::class),
-        ])->makePartial();
-
-        $cli->shouldReceive('runAsUser')->once()->with('brew --cellar php@8.0')->andReturn(BREW_PREFIX.'/Cellar/php@8.0');
-        $cli->shouldReceive('runAsUser')->once()->with('brew info --json php@8.0')->andReturn('[{"installed":[{"version":"8.0.5"}]}]');
-        $files->shouldReceive('exists')->once()->with(BREW_PREFIX.'/Cellar/php@8.0/8.0.5/bin/php')->andReturn(true);
-
-        $this->assertEquals(BREW_PREFIX.'/Cellar/php@8.0/8.0.5/bin/php', $brewMock->getPhpExecutablePath('php@8.0'));
-
-        // When brew info has a version that was manually installed
-        $brewMock = Mockery::mock(Brew::class, [
-            $cli = Mockery::mock(CommandLine::class),
-            $files = Mockery::mock(Filesystem::class),
-        ])->makePartial();
-
-        $cli->shouldReceive('runAsUser')->once()->with('brew --cellar php@8.1')->andReturn(BREW_PREFIX.'/Cellar/php@8.1');
-        $cli->shouldReceive('runAsUser')->once()->with('brew info --json php@8.1')
-            ->andReturn('[{"installed":[{"version":"8.1.1", "installed_as_dependency":true}, {"version":"8.1.2", "installed_as_dependency":false}]}]');
-        $files->shouldReceive('exists')->once()->with(BREW_PREFIX.'/Cellar/php@8.1/8.1.2/bin/php')->andReturn(true);
-
-        $this->assertEquals(BREW_PREFIX.'/Cellar/php@8.1/8.1.2/bin/php', $brewMock->getPhpExecutablePath('php@8.1'));
-
-        // When brew info has no version that was installed manually, it should pick the last PHP version
-        $brewMock = Mockery::mock(Brew::class, [
-            $cli = Mockery::mock(CommandLine::class),
-            $files = Mockery::mock(Filesystem::class),
-        ])->makePartial();
-
-        $cli->shouldReceive('runAsUser')->once()->with('brew --cellar php@7.4')->andReturn(BREW_PREFIX.'/Cellar/php@7.4');
-        $cli->shouldReceive('runAsUser')->once()->with('brew info --json php@7.4')
-            ->andReturn('[{"installed":[{"version":"7.4.1", "installed_as_dependency":false}, {"version":"7.4.3", "installed_as_dependency":false}]}]');
-        $files->shouldReceive('exists')->once()->with(BREW_PREFIX.'/Cellar/php@7.4/7.4.3/bin/php')->andReturn(true);
-
-        $this->assertEquals(BREW_PREFIX.'/Cellar/php@7.4/7.4.3/bin/php', $brewMock->getPhpExecutablePath('php@7.4'));
-
-        // When user has installed directly though `shivammathur/homebrew-php`
-        $brewMock = Mockery::mock(Brew::class, [
-            $cli = Mockery::mock(CommandLine::class),
-            $files = Mockery::mock(Filesystem::class),
-        ])->makePartial();
-
-        $cli->shouldReceive('runAsUser')->once()->with('brew --cellar php@7.4')->andReturn(BREW_PREFIX.'/Cellar/php@7.4');
-        $cli->shouldReceive('runAsUser')->once()->with('brew info --json php@7.4')->andReturn(false);
-        $files->shouldReceive('exists')->once()->with(BREW_PREFIX.'/opt/php@7.4/bin/php')->andReturn(true);
-
-        $this->assertEquals(BREW_PREFIX.'/opt/php@7.4/bin/php', $brewMock->getPhpExecutablePath('php@7.4'));
+        $this->assertFalse(resolve(Brew::class)->isPhpVersionsEqual('php71', 'php@70'));
+        $this->assertFalse(resolve(Brew::class)->isPhpVersionsEqual('php71', '72'));
     }
 
     /**

--- a/tests/BrewTest.php
+++ b/tests/BrewTest.php
@@ -425,9 +425,9 @@ class BrewTest extends Yoast\PHPUnitPolyfills\TestCases\TestCase
 
         $files->shouldReceive('exists')->once()->with(BREW_PREFIX.'/opt/php@7.4/bin/php')->andReturn(false);
         $files->shouldReceive('exists')->with(BREW_PREFIX.'/opt/php74/bin/php')->andReturn(false);
-        $files->shouldReceive('isLink')->with(BREW_PREFIX."/opt/php")->andReturn(true);
-        $files->shouldReceive('readLink')->with(BREW_PREFIX."/opt/php")->andReturn('../Cellar/php@7.4/7.4.13/bin/php');
-        $this->assertEquals(BREW_PREFIX."/opt/php/bin/php", $brewMock->getPhpExecutablePath('php@7.4'));
+        $files->shouldReceive('isLink')->with(BREW_PREFIX.'/opt/php')->andReturn(true);
+        $files->shouldReceive('readLink')->with(BREW_PREFIX.'/opt/php')->andReturn('../Cellar/php@7.4/7.4.13/bin/php');
+        $this->assertEquals(BREW_PREFIX.'/opt/php/bin/php', $brewMock->getPhpExecutablePath('php@7.4'));
 
         // When the default PHP is not the version we are looking for
         $brewMock = Mockery::mock(Brew::class, [
@@ -437,9 +437,9 @@ class BrewTest extends Yoast\PHPUnitPolyfills\TestCases\TestCase
 
         $files->shouldReceive('exists')->once()->with(BREW_PREFIX.'/opt/php@7.4/bin/php')->andReturn(false);
         $files->shouldReceive('exists')->with(BREW_PREFIX.'/opt/php74/bin/php')->andReturn(false);
-        $files->shouldReceive('isLink')->with(BREW_PREFIX."/opt/php")->andReturn(true);
-        $files->shouldReceive('readLink')->with(BREW_PREFIX."/opt/php")->andReturn('../Cellar/php@8.1/8.1.13/bin/php');
-        $this->assertEquals(BREW_PREFIX."/bin/php", $brewMock->getPhpExecutablePath('php@7.4')); // Could not find a version, so retuned the default binary
+        $files->shouldReceive('isLink')->with(BREW_PREFIX.'/opt/php')->andReturn(true);
+        $files->shouldReceive('readLink')->with(BREW_PREFIX.'/opt/php')->andReturn('../Cellar/php@8.1/8.1.13/bin/php');
+        $this->assertEquals(BREW_PREFIX.'/bin/php', $brewMock->getPhpExecutablePath('php@7.4')); // Could not find a version, so retuned the default binary
 
         // When no PHP Version is provided
         $brewMock = Mockery::mock(Brew::class, [

--- a/tests/BrewTest.php
+++ b/tests/BrewTest.php
@@ -395,49 +395,73 @@ class BrewTest extends Yoast\PHPUnitPolyfills\TestCases\TestCase
         $brewMock->restartLinkedPhp();
     }
 
+    public function test_it_can_get_php_binary_path_from_php_version_and_create_symblink()
+    {
+        // Scenario when there is no linked Valet PHP exists
+        $brewMock = Mockery::mock(Brew::class, [Mockery::mock(CommandLine::class), $files = Mockery::mock(Filesystem::class)])->makePartial();
+        $files->shouldReceive('isLink')->once()->with(BREW_PREFIX."/bin/valetphp74")->andReturn(false);
+        $files->shouldReceive('symlinkAsUser')->once()->withArgs([BREW_PREFIX."/Cellar/php@7.4/7.4.6/bin/php", BREW_PREFIX."/bin/valetphp74"]);
+        $brewMock->shouldReceive('getPhpBinaryPath')->once()->with('php@7.4')->andReturn(BREW_PREFIX."/Cellar/php@7.4/7.4.6/bin/php");
+        $this->assertEquals(BREW_PREFIX."/Cellar/php@7.4/7.4.6/bin/php", $brewMock->whichPhp('php@7.4'));
+
+        // Scenario when there is a linked Valet PHP exists
+        $brewMock = Mockery::mock(Brew::class, [Mockery::mock(CommandLine::class), $files = Mockery::mock(Filesystem::class)])->makePartial();
+        $brewMock->shouldNotHaveReceived('getPhpBinaryPath');
+        $files->shouldReceive('isLink')->once()->with(BREW_PREFIX."/bin/valetphp81")->andReturn(true);
+        $files->shouldReceive('readLink')->once()->with(BREW_PREFIX."/bin/valetphp81")->andReturn(BREW_PREFIX."/Cellar/php@8.1/8.1.5/bin/php");
+        $files->shouldReceive('exists')->once()->with(BREW_PREFIX."/Cellar/php@8.1/8.1.5/bin/php")->andReturn(true);
+        $files->shouldNotHaveReceived('symlinkAsUser');
+        $this->assertEquals(BREW_PREFIX."/Cellar/php@8.1/8.1.5/bin/php", $brewMock->whichPhp('php@8.1'));
+
+        // Check with $skipCache enabled
+        $brewMock = Mockery::mock(Brew::class, [Mockery::mock(CommandLine::class), $files = Mockery::mock(Filesystem::class)])->makePartial();
+        $brewMock->shouldReceive('getPhpBinaryPath')->once()->with('php@7.4')->andReturn(BREW_PREFIX."/Cellar/php@7.4/7.4.6/bin/php");
+        $files->shouldReceive('symlinkAsUser')->once()->withArgs([BREW_PREFIX."/Cellar/php@7.4/7.4.6/bin/php", BREW_PREFIX."/bin/valetphp74"]);
+        $this->assertEquals(BREW_PREFIX."/Cellar/php@7.4/7.4.6/bin/php", $brewMock->whichPhp('php@7.4', true));
+
+        // Scenario when non PHP Version is proivided
+        $brewMock = Mockery::mock(Brew::class, [Mockery::mock(CommandLine::class),  Mockery::mock(Filesystem::class)])->makePartial();
+        $this->assertEquals(BREW_PREFIX.'/bin/php', $brewMock->whichPhp(null));
+    }
+
     public function test_it_can_get_php_binary_path_from_php_version()
     {
-        // Scenario when there is no linked valet php exists
-        $files = Mockery::mock(Filesystem::class);
-        $cli = Mockery::mock(CommandLine::class);
-        $files->shouldReceive('isLink')->once()->with(BREW_PREFIX."/bin/valetphp74")->andReturn(false);
+        // linked_keg
+        $brewMock = Mockery::mock(Brew::class, [$cli = Mockery::mock(CommandLine::class), $files = Mockery::mock(Filesystem::class)])->makePartial();
         $cli->shouldReceive('runAsUser')->once()->with("brew --cellar php@7.4")->andReturn(BREW_PREFIX."/Cellar/php@7.4");
         $cli->shouldReceive('runAsUser')->once()->with("brew info --json php@7.4")->andReturn('[{"linked_keg":"7.4.6","installed":[{"version":"7.4.5"}]}]');
         $files->shouldReceive('exists')->once()->with(BREW_PREFIX."/Cellar/php@7.4/7.4.6/bin/php")->andReturn(true);
-        $files->shouldReceive('symlinkAsUser')->once()->withArgs([BREW_PREFIX."/Cellar/php@7.4/7.4.6/bin/php", BREW_PREFIX."/bin/valetphp74"]);
-        swap(CommandLine::class, $cli);
-        swap(Filesystem::class, $files);
-        $this->assertEquals(BREW_PREFIX."/Cellar/php@7.4/7.4.6/bin/php", resolve(Brew::class)->getPhpBinaryPath('php@7.4'));
+        $this->assertEquals(BREW_PREFIX."/Cellar/php@7.4/7.4.6/bin/php", $brewMock->getPhpBinaryPath('php@7.4'));
+
+        // no linked_keg
+        $brewMock = Mockery::mock(Brew::class, [$cli = Mockery::mock(CommandLine::class), $files = Mockery::mock(Filesystem::class)])->makePartial();
+        $cli->shouldReceive('runAsUser')->once()->with("brew --cellar php@8.0")->andReturn(BREW_PREFIX."/Cellar/php@8.0");
+        $cli->shouldReceive('runAsUser')->once()->with("brew info --json php@8.0")->andReturn('[{"installed":[{"version":"8.0.5"}]}]');
+        $files->shouldReceive('exists')->once()->with(BREW_PREFIX."/Cellar/php@8.0/8.0.5/bin/php")->andReturn(true);
+        $this->assertEquals(BREW_PREFIX."/Cellar/php@8.0/8.0.5/bin/php", $brewMock->getPhpBinaryPath('php@8.0'));
+
+        // installed_as_dependency
+        $brewMock = Mockery::mock(Brew::class, [$cli = Mockery::mock(CommandLine::class), $files = Mockery::mock(Filesystem::class)])->makePartial();
+        $cli->shouldReceive('runAsUser')->once()->with("brew --cellar php@8.1")->andReturn(BREW_PREFIX."/Cellar/php@8.1");
+        $cli->shouldReceive('runAsUser')->once()->with("brew info --json php@8.1")
+            ->andReturn('[{"installed":[{"version":"8.1.1", "installed_as_dependency":true}, {"version":"8.1.2", "installed_as_dependency":false}]}]');
+        $files->shouldReceive('exists')->once()->with(BREW_PREFIX."/Cellar/php@8.1/8.1.2/bin/php")->andReturn(true);
+        $this->assertEquals(BREW_PREFIX."/Cellar/php@8.1/8.1.2/bin/php", $brewMock->getPhpBinaryPath('php@8.1'));
+
+        // installed_as_dependency 2
+        $brewMock = Mockery::mock(Brew::class, [$cli = Mockery::mock(CommandLine::class), $files = Mockery::mock(Filesystem::class)])->makePartial();
+        $cli->shouldReceive('runAsUser')->once()->with("brew --cellar php@7.4")->andReturn(BREW_PREFIX."/Cellar/php@7.4");
+        $cli->shouldReceive('runAsUser')->once()->with("brew info --json php@7.4")
+            ->andReturn('[{"installed":[{"version":"7.4.1", "installed_as_dependency":false}, {"version":"7.4.3", "installed_as_dependency":false}]}]');
+        $files->shouldReceive('exists')->once()->with(BREW_PREFIX."/Cellar/php@7.4/7.4.3/bin/php")->andReturn(true);
+        $this->assertEquals(BREW_PREFIX."/Cellar/php@7.4/7.4.3/bin/php", $brewMock->getPhpBinaryPath('php@7.4'));
 
         // Scenario when user has installed directly though shivammathur/homebrew-php
-        $files = Mockery::mock(Filesystem::class);
-        $cli = Mockery::mock(CommandLine::class);
-        $files->shouldReceive('isLink')->once()->with(BREW_PREFIX."/bin/valetphp74")->andReturn(false);
+        $brewMock = Mockery::mock(Brew::class, [$cli = Mockery::mock(CommandLine::class), $files = Mockery::mock(Filesystem::class)])->makePartial();
         $cli->shouldReceive('runAsUser')->once()->with("brew --cellar php@7.4")->andReturn(BREW_PREFIX."/Cellar/php@7.4");
-        $cli->shouldReceive('runAsUser')->once()->with("brew info --json php@7.4")->andReturn('[{"installed":[{"version":"7.4.5"}]}]');
-        $files->shouldReceive('exists')->once()->with(BREW_PREFIX."/Cellar/php@7.4/7.4.5/bin/php")->andReturn(false);
+        $cli->shouldReceive('runAsUser')->once()->with("brew info --json php@7.4")->andReturn(false);
         $files->shouldReceive('exists')->once()->with(BREW_PREFIX."/opt/php@7.4/bin/php")->andReturn(true);
-        $files->shouldReceive('symlinkAsUser')->once()->withArgs([BREW_PREFIX ."/opt/php@7.4/bin/php", BREW_PREFIX."/bin/valetphp74"]);
-        swap(CommandLine::class, $cli);
-        swap(Filesystem::class, $files);
-        $this->assertEquals(BREW_PREFIX ."/opt/php@7.4/bin/php", resolve(Brew::class)->getPhpBinaryPath('php@7.4'));
-
-        // Scenario when there is a linked valet php exists
-        $files = Mockery::mock(Filesystem::class);
-        $cli = Mockery::mock(CommandLine::class);
-        $files->shouldReceive('isLink')->once()->with(BREW_PREFIX."/bin/valetphp74")->andReturn(true);
-        $files->shouldReceive('readLink')->once()->with(BREW_PREFIX."/bin/valetphp74")->andReturn(BREW_PREFIX."/Cellar/php@7.4/7.4.5/bin/php");
-        $files->shouldReceive('exists')->once()->with(BREW_PREFIX."/Cellar/php@7.4/7.4.5/bin/php")->andReturn(true);
-        swap(CommandLine::class, $cli);
-        swap(Filesystem::class, $files);
-        $this->assertEquals(BREW_PREFIX."/bin/valetphp74", resolve(Brew::class)->getPhpBinaryPath('php@7.4'));
-
-        // Scenario when non php version is proivided
-        $files = Mockery::mock(Filesystem::class);
-        $cli = Mockery::mock(CommandLine::class);
-        swap(CommandLine::class, $cli);
-        swap(Filesystem::class, $files);
-        $this->assertEquals(BREW_PREFIX.'/bin/php', resolve(Brew::class)->getPhpBinaryPath(null));
+        $this->assertEquals(BREW_PREFIX."/opt/php@7.4/bin/php", $brewMock->getPhpBinaryPath('php@7.4'));
     }
 
     /**

--- a/tests/SiteTest.php
+++ b/tests/SiteTest.php
@@ -819,6 +819,55 @@ class SiteTest extends Yoast\PHPUnitPolyfills\TestCases\TestCase
 
         $this->assertSame(['helloworld.tld'], $sites);
     }
+
+    public function test_it_can_read_php_rc_version()
+    {
+        $config = Mockery::mock(Configuration::class);
+        $files = Mockery::mock(Filesystem::class);
+
+        swap(Configuration::class, $config);
+        swap(Filesystem::class, $files);
+
+        $siteMock = Mockery::mock(Site::class, [
+            resolve(Configuration::class),
+            resolve(CommandLine::class),
+            resolve(Filesystem::class)
+        ])->makePartial();
+
+        swap(Site::class, $siteMock);
+
+        $config->shouldReceive('read')
+            ->andReturn(['tld' => 'test', 'loopback' => VALET_LOOPBACK, 'paths' => []]);
+
+        $siteMock->shouldReceive('parked')
+            ->andReturn(collect([
+                'site1' => [
+                    'site' => 'site1',
+                    'secured' => '',
+                    'url' => 'http://site1.test',
+                    'path' => '/Users/name/code/site1',
+                ],
+            ]));
+
+        $siteMock->shouldReceive('links')->andReturn(collect([
+            'site2' => [
+                'site' => 'site2',
+                'secured' => 'X',
+                'url' => 'http://site2.test',
+                'path' => '/Users/name/some-other-directory/site2',
+            ],
+        ]));
+
+        $files->shouldReceive('exists')->with('/Users/name/code/site1/.valetphprc')->andReturn(true);
+        $files->shouldReceive('get')->with('/Users/name/code/site1/.valetphprc')->andReturn('php@8.1');
+
+        $files->shouldReceive('exists')->with('/Users/name/some-other-directory/site2/.valetphprc')->andReturn(true);
+        $files->shouldReceive('get')->with('/Users/name/some-other-directory/site2/.valetphprc')->andReturn('php@8.0');
+
+        $this->assertEquals('php@8.1', $siteMock->phpRcVersion('site1'));
+        $this->assertEquals('php@8.0', $siteMock->phpRcVersion('site2'));
+        $this->assertEquals(null, $siteMock->phpRcVersion('site3')); // Site doesn't exists
+    }
 }
 
 class CommandLineFake extends CommandLine

--- a/tests/SiteTest.php
+++ b/tests/SiteTest.php
@@ -831,7 +831,7 @@ class SiteTest extends Yoast\PHPUnitPolyfills\TestCases\TestCase
         $siteMock = Mockery::mock(Site::class, [
             resolve(Configuration::class),
             resolve(CommandLine::class),
-            resolve(Filesystem::class)
+            resolve(Filesystem::class),
         ])->makePartial();
 
         swap(Site::class, $siteMock);

--- a/valet
+++ b/valet
@@ -82,13 +82,17 @@ then
 
     exit
 
+# Proxy PHP commands to the "php" binary on the isolated site
 elif [[ "$1" = "php" ]]
 then
-    $(php "$DIR/cli/valet.php" isolated --site=$(basename "$PWD") --binary) "${@:2}"
+    $(php "$DIR/cli/valet.php" which-php) "${@:2}"
+    exit
 
+# Proxy composer commands with the "php" binary on the isolated site
 elif [[ "$1" = "composer" ]]
 then
-   $(php "$DIR/cli/valet.php" isolated --site=$(basename "$PWD") --binary) $(which composer) "${@:2}"
+    $(php "$DIR/cli/valet.php" which-php) $(which composer) "${@:2}"
+    exit
 
 # Finally, for every other command we will just proxy into the PHP tool
 # and let it handle the request. These are commands which can be run

--- a/valet
+++ b/valet
@@ -20,12 +20,6 @@ then
     DIR=$(php -r "echo realpath('$DIR/../laravel/valet');")
 fi
 
-if [[ "$EUID" -ne 0 ]]
-then
-    sudo USER="$USER" --preserve-env "$SOURCE" "$@"
-    exit
-fi
-
 # If the command is the "share" command we will need to resolve out any
 # symbolic links for the site. Before starting Ngrok, we will fire a
 # process to retrieve the live Ngrok tunnel URL in the background.
@@ -88,9 +82,23 @@ then
 
     exit
 
+elif [[ "$1" = "php" ]]
+then
+    php "${@:2}"
+
+elif [[ "$1" = "composer" ]]
+then
+   php /usr/local/bin/composer "${@:2}"
+
 # Finally, for every other command we will just proxy into the PHP tool
 # and let it handle the request. These are commands which can be run
 # without sudo and don't require taking over terminals like Ngrok.
 else
+    if [[ "$EUID" -ne 0 ]]
+    then
+        sudo USER="$USER" --preserve-env "$SOURCE" "$@"
+        exit
+    fi
+
     php "$DIR/cli/valet.php" "$@"
 fi

--- a/valet
+++ b/valet
@@ -75,23 +75,25 @@ then
     ARCH=$(uname -m)
 
     if [[ $ARCH == 'arm64' ]]; then
-        sudo -u "$USER" "$DIR/bin/ngrok-arm" http "$HOST.$TLD:$PORT" -host-header=rewrite $PARAMS
+        "$DIR/bin/ngrok-arm" http "$HOST.$TLD:$PORT" -host-header=rewrite $PARAMS
     else
-        sudo -u "$USER" "$DIR/bin/ngrok" http "$HOST.$TLD:$PORT" -host-header=rewrite $PARAMS
+        "$DIR/bin/ngrok" http "$HOST.$TLD:$PORT" -host-header=rewrite $PARAMS
     fi
 
     exit
 
-# Proxy PHP commands to the "php" binary on the isolated site
+# Proxy PHP commands to the "php" executable on the isolated site
 elif [[ "$1" = "php" ]]
 then
     $(php "$DIR/cli/valet.php" which-php) "${@:2}"
+
     exit
 
-# Proxy composer commands with the "php" binary on the isolated site
+# Proxy Composer commands with the "php" executable on the isolated site
 elif [[ "$1" = "composer" ]]
 then
     $(php "$DIR/cli/valet.php" which-php) $(which composer) "${@:2}"
+
     exit
 
 # Finally, for every other command we will just proxy into the PHP tool

--- a/valet
+++ b/valet
@@ -84,11 +84,11 @@ then
 
 elif [[ "$1" = "php" ]]
 then
-    php "${@:2}"
+    $(php "$DIR/cli/valet.php" isolated --site=$(basename "$PWD") --binary) "${@:2}"
 
 elif [[ "$1" = "composer" ]]
 then
-   php /usr/local/bin/composer "${@:2}"
+   $(php "$DIR/cli/valet.php" isolated --site=$(basename "$PWD") --binary) $(which composer) "${@:2}"
 
 # Finally, for every other command we will just proxy into the PHP tool
 # and let it handle the request. These are commands which can be run


### PR DESCRIPTION
This PR introduces 3 new valet commands.  These will help users to run PHP and Composer commands with isolated site's PHP version on the CLI. 

1. `valet php ...` will proxy PHP Commands with isolated PHP version
2. `valet composer ...` will proxy Composer Commands with isolated PHP version
3. `valet which-php` outputs the PHP executable path for a site. For isolated site it would output the isolated PHP executable path. But non-isolated site will just output the linked default PHP path. The other two commands are dependent on this one to find the PHP executable. 

<details>
<summary> 🔽 Video demonstration </summary>

https://user-images.githubusercontent.com/13833460/159581055-4c1b7494-feb5-420a-946f-f89512597cc3.mp4
</details>

## Syntax
Though the [original idea](https://github.com/laravel/valet/discussions/1211) was to create a command like `valet run` that would proxy PHP calls to an isolated PHP version. But I kinda like the [laravel sail](https://github.com/laravel/sail/blob/1.x/bin/sail) style, so kept it this way. 

## Quick note on `which-php` command
Currently `valet which-php` uses PHP to find the correct executable path. Initially, I thought of doing this with vanilla bash. But then thought if it would bring any benefit, also would make it hard to test it. Some of the [codes](https://github.com/NasirNobin/valet/pull/8/files) are still here, in case if we want to explore that route. 

## Symlinking PHP executables to make it a bit fast
It's using a combination of `brew --cellar` and `brew info` commands to determine the correct PHP executable path, So each time user runs `valet php -v` it would go through the process of extracting the PATH, which is very slow. Ended up adding a caching mechanism that creates a symlink at `/opt/homebrew/bin/valetphp81` location, that directs toward the actual path for that version. 

So next time a user runs `valet php -v` it would resolve the PHP path much faster from the symlink. 

Please do suggest if you think there's an easier way to find the PHP executable for a given PHP version. I'll be happy to refactor. 

## Alternative Solution
Before starting to work on this PR, I was working on another external solution called [zsh-valet](https://github.com/NasirNobin/zsh-valet) to solve the very same problem, still in progress. I'll try to manage that as an external zsh package. 