### PR TITLE
Valet fetch-share-url issue fix

### DIFF
--- a/cli/Valet/Ngrok.php
+++ b/cli/Valet/Ngrok.php
@@ -2,8 +2,8 @@
 
 namespace Valet;
 
-use Exception;
 use DomainException;
+use Exception;
 use GuzzleHttp\Client;
 
 class Ngrok


### PR DESCRIPTION
Every time I run `valet share` it opens the tunnel successfully, then shows an error message related to fetch-share-url with this error message.  

```
cURL error 7: Failed to connect to 127.0.0.1 port 4041 after 0 ms: 
Connection refused (see https://curl.haxx.se/libcurl/c/libcurl-errors.html)
for http://127.0.0.1:4041/api/tunnels
```

<details>
<summary> 🔽 Video demonstration of the issue </summary>

https://user-images.githubusercontent.com/13833460/193427493-70538245-a7b2-4634-b8e8-5b5967888a5f.mp4
</details>

This error was happening for a while. I ignored this for a few months. A few days back I was collaborating with a co-worker and he thought valet share is broken as this error always popup for him as well. So I thought of finding the underlying issue. 

## The issue:
Tunnel URL checker `Ngrok::currentTunnelUrl` is supposed to retry 20 times until it finds a tunnel URL on `127.0.0.1:4040/api/tunnels` endpoint. Then again it should retry with 127.0.0.1:4041 port. 

But that loop was getting exited when Ngrok is returning a 200 response but the tunnel URL is still not in the response. 

In another scenario, it wasn't reaching the `4041` port part as the `retry` helper is throwing an exception after trying 20 times on the `4040` port and the script is exiting before trying the 4041 port. 

This PR should fix both issues. 